### PR TITLE
geom_alt props

### DIFF
--- a/data/421/168/189/421168189.geojson
+++ b/data/421/168/189/421168189.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"DZ",
     "wof:created":1459008757,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"99f41b8c6ae435e06bffaac6b23caa43",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421168189,
-    "wof:lastmodified":1566583480,
+    "wof:lastmodified":1582348644,
     "wof:name":"Zeribet el Oued",
     "wof:parent_id":85670827,
     "wof:placetype":"locality",

--- a/data/421/174/649/421174649.geojson
+++ b/data/421/174/649/421174649.geojson
@@ -655,6 +655,9 @@
     },
     "wof:country":"DZ",
     "wof:created":1459009039,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"418f156e07e8e93fd82eaa22d93d148a",
     "wof:hierarchy":[
         {
@@ -665,7 +668,7 @@
         }
     ],
     "wof:id":421174649,
-    "wof:lastmodified":1566583489,
+    "wof:lastmodified":1582348644,
     "wof:name":"Algiers",
     "wof:parent_id":85670761,
     "wof:placetype":"locality",

--- a/data/421/195/273/421195273.geojson
+++ b/data/421/195/273/421195273.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"DZ",
     "wof:created":1459009838,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"97dd6902d77b17b3ab53556bd770cec3",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":421195273,
-    "wof:lastmodified":1561791091,
+    "wof:lastmodified":1582348644,
     "wof:name":"El Golea",
     "wof:parent_id":85670749,
     "wof:placetype":"locality",

--- a/data/421/205/389/421205389.geojson
+++ b/data/421/205/389/421205389.geojson
@@ -217,6 +217,9 @@
     },
     "wof:country":"DZ",
     "wof:created":1459010223,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"5f92ab08f1c563b06d31de3186954a66",
     "wof:hierarchy":[
         {
@@ -227,7 +230,7 @@
         }
     ],
     "wof:id":421205389,
-    "wof:lastmodified":1566583488,
+    "wof:lastmodified":1582348644,
     "wof:name":"Hassi Messaoud",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",

--- a/data/856/324/51/85632451.geojson
+++ b/data/856/324/51/85632451.geojson
@@ -1028,7 +1028,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1104,7 +1103,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1582348636,
+    "wof:lastmodified":1583228753,
     "wof:name":"Algeria",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/324/51/85632451.geojson
+++ b/data/856/324/51/85632451.geojson
@@ -1028,6 +1028,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1083,6 +1084,10 @@
     },
     "wof:country":"DZ",
     "wof:country_alpha3":"DZA",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"85a2b7533679533d458d8a9412070589",
     "wof:hierarchy":[
         {
@@ -1099,7 +1104,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1566582928,
+    "wof:lastmodified":1582348636,
     "wof:name":"Algeria",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/858/021/19/85802119.geojson
+++ b/data/858/021/19/85802119.geojson
@@ -137,6 +137,10 @@
         "wk:page":"Bab El Oued"
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b6a24bb0db8947f2396e7f24ddaf33d",
     "wof:hierarchy":[
         {
@@ -151,7 +155,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582934,
+    "wof:lastmodified":1582348637,
     "wof:name":"Bab el Oued",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/23/85802123.geojson
+++ b/data/858/021/23/85802123.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1167954
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"988c3b56052e330c77a3df01060f0b14",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582935,
+    "wof:lastmodified":1582348638,
     "wof:name":"Camp Inf\u00e9rieur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/27/85802127.geojson
+++ b/data/858/021/27/85802127.geojson
@@ -66,6 +66,9 @@
         "gp:id":1253859
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fdcb017b3c55922fc2b94f933cb4958",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582933,
+    "wof:lastmodified":1582348637,
     "wof:name":"Cit\u00e9 Chancel",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/31/85802131.geojson
+++ b/data/858/021/31/85802131.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1117307
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6eea2a1fd227f8fa6945ff155b273ad7",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582934,
+    "wof:lastmodified":1582348637,
     "wof:name":"El Anasser",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/35/85802135.geojson
+++ b/data/858/021/35/85802135.geojson
@@ -148,6 +148,9 @@
         "wd:id":"Q2673474"
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54284979a8dfbcb409bfd1ad609a8376",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582933,
+    "wof:lastmodified":1582348637,
     "wof:name":"El Biar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/41/85802141.geojson
+++ b/data/858/021/41/85802141.geojson
@@ -137,6 +137,10 @@
         "wk:page":"El Harrach"
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9df19be4654123a42454a5b3bd5e844",
     "wof:hierarchy":[
         {
@@ -151,7 +155,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582934,
+    "wof:lastmodified":1582348638,
     "wof:name":"El Harrach",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/45/85802145.geojson
+++ b/data/858/021/45/85802145.geojson
@@ -131,6 +131,10 @@
         "qs_pg:id":1167957
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff23944acc2ed29c04eec4c945057ff3",
     "wof:hierarchy":[
         {
@@ -145,7 +149,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582933,
+    "wof:lastmodified":1582348637,
     "wof:name":"Hamma",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/49/85802149.geojson
+++ b/data/858/021/49/85802149.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q660003"
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0414bbba6c3089b0579fb68bb2d0da5c",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582935,
+    "wof:lastmodified":1582348638,
     "wof:name":"Husse\u00efn Dey",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/53/85802153.geojson
+++ b/data/858/021/53/85802153.geojson
@@ -174,6 +174,10 @@
         "wd:id":"Q89468"
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac8c23eb40bb7358cc7ff226e3ca3f7e",
     "wof:hierarchy":[
         {
@@ -188,7 +192,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582934,
+    "wof:lastmodified":1582348637,
     "wof:name":"Kasbah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/59/85802159.geojson
+++ b/data/858/021/59/85802159.geojson
@@ -98,6 +98,10 @@
         "qs_pg:id":1167959
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8bee9d826c52321111976bc6bcd1286d",
     "wof:hierarchy":[
         {
@@ -112,7 +116,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582932,
+    "wof:lastmodified":1582348637,
     "wof:name":"La Marine",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/63/85802163.geojson
+++ b/data/858/021/63/85802163.geojson
@@ -66,6 +66,9 @@
         "gp:id":1255339
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"827314a499cf3c41e3cb75dcb306f98d",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582934,
+    "wof:lastmodified":1582348637,
     "wof:name":"Les Tagarins",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/65/85802165.geojson
+++ b/data/858/021/65/85802165.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1167965
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"52f0a75752f0ac9773e5f992bfaeae3f",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582934,
+    "wof:lastmodified":1582348637,
     "wof:name":"Montpensier",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/69/85802169.geojson
+++ b/data/858/021/69/85802169.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1167967
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de2c44e52dccf89ac4622140c64323f9",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582933,
+    "wof:lastmodified":1582348637,
     "wof:name":"Mustapha Sup\u00e9rieur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/73/85802173.geojson
+++ b/data/858/021/73/85802173.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1024228
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"207de0a3776bbe5ce8687bea33902d71",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582933,
+    "wof:lastmodified":1582348637,
     "wof:name":"Oued Korine",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/79/85802179.geojson
+++ b/data/858/021/79/85802179.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":267947
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bcb39684b0a3c5c24e15d8057a910eda",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582934,
+    "wof:lastmodified":1582348637,
     "wof:name":"Oulad Soltane",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/83/85802183.geojson
+++ b/data/858/021/83/85802183.geojson
@@ -84,6 +84,9 @@
         "gp:id":1257067
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59b746a38747d9be47acd9bfdf6d74c2",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582935,
+    "wof:lastmodified":1582348638,
     "wof:name":"Agha",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/13/85859513.geojson
+++ b/data/858/595/13/85859513.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":236205
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"cabe7aa76ab7f8ea467dccfd29ac496a",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582932,
+    "wof:lastmodified":1582348637,
     "wof:name":"Alger Port Said",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/15/85859515.geojson
+++ b/data/858/595/15/85859515.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":430822
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e48470f3383b9e01e0c42f53433cf9e4",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582931,
+    "wof:lastmodified":1582348637,
     "wof:name":"Alger Palais du Peuple",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/595/31/85859531.geojson
+++ b/data/858/595/31/85859531.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":1251442
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e4ae32834e03ad60310503bece2215c3",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582931,
+    "wof:lastmodified":1582348637,
     "wof:name":"Bologuine Ibnou Ziri",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/642/69/85864269.geojson
+++ b/data/858/642/69/85864269.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1179223
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5eb69cf828e8a8e3d713b1230fae63c6",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582932,
+    "wof:lastmodified":1582348637,
     "wof:name":"Telemly",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/642/71/85864271.geojson
+++ b/data/858/642/71/85864271.geojson
@@ -66,6 +66,9 @@
         "gp:id":22528470
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"73b7413b627e25fab1480cbc2d0cec56",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582932,
+    "wof:lastmodified":1582348637,
     "wof:name":"Les Trembles",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/642/81/85864281.geojson
+++ b/data/858/642/81/85864281.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":1154387
     },
     "wof:country":"DZ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56a350434d0bf72ac09c716a085a4a8d",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566582932,
+    "wof:lastmodified":1582348637,
     "wof:name":"Alger El Kettani",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/436/901/890436901.geojson
+++ b/data/890/436/901/890436901.geojson
@@ -216,6 +216,9 @@
     },
     "wof:country":"DZ",
     "wof:created":1469052131,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"06f062ef64ae34a63ec03b779b702fb5",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":890436901,
-    "wof:lastmodified":1566583510,
+    "wof:lastmodified":1582348644,
     "wof:name":"Timimoun",
     "wof:parent_id":85670677,
     "wof:placetype":"locality",

--- a/data/890/440/141/890440141.geojson
+++ b/data/890/440/141/890440141.geojson
@@ -278,6 +278,9 @@
     },
     "wof:country":"DZ",
     "wof:created":1469052264,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2da1af3d52dc0e6ac28e9f52e901968",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         }
     ],
     "wof:id":890440141,
-    "wof:lastmodified":1566583507,
+    "wof:lastmodified":1582348644,
     "wof:name":"Touggourt",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.