### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/174/259/421174259.geojson
+++ b/data/421/174/259/421174259.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":33.370749,
     "geom:longitude":6.866884,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "El Oued Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"6.846884,33.350749,6.886884,33.390749",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421174259,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423088,
     "wof:name":"El Oued",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",

--- a/data/421/174/259/421174259.geojson
+++ b/data/421/174/259/421174259.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":33.370749,
     "geom:longitude":6.866884,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "El Oued Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"6.846884,33.350749,6.886884,33.390749",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0648\u0627\u062f\u064a"
     ],
     "name:eng_x_preferred":[
+        "El Oued"
+    ],
+    "name:eng_x_variant":[
         "El Oued Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421174259,
-    "wof:lastmodified":1601068401,
-    "wof:name":"El Oued Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"El Oued",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/174/259/421174259.geojson
+++ b/data/421/174/259/421174259.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0648\u0627\u062f\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "El Oued Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421174259,
-    "wof:lastmodified":1566583488,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0648\u0627\u062f\u064a",
+    "wof:lastmodified":1601068401,
+    "wof:name":"El Oued Province",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/563/421189563.geojson
+++ b/data/421/189/563/421189563.geojson
@@ -6,16 +6,10 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"7.7579575,36.9044695,7.7579575,36.9044695",
+    "geom:bbox":"7.757957,36.904469,7.757957,36.904469",
     "geom:latitude":36.904469,
     "geom:longitude":7.757957,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Annaba Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"7.7379575,36.8844695,7.7779575,36.9244695",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -63,7 +57,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1459009628,
-    "wof:geomhash":"9cdea6caac48328491a5d227706e83c4",
+    "wof:geomhash":"e33d773b937fc0e63a4b46104c8e7efb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189563,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423086,
     "wof:name":"Annaba",
     "wof:parent_id":85670713,
     "wof:placetype":"locality",
@@ -83,10 +77,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    7.7579575,
-    36.9044695,
-    7.7579575,
-    36.9044695
+    7.757957,
+    36.904469,
+    7.757957,
+    36.904469
 ],
-  "geometry": {"coordinates":[7.7579575,36.9044695],"type":"Point"}
+  "geometry": {"coordinates":[7.757957,36.904469],"type":"Point"}
 }

--- a/data/421/189/563/421189563.geojson
+++ b/data/421/189/563/421189563.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.904469,
     "geom:longitude":7.757957,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Annaba Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"7.7379575,36.8844695,7.7779575,36.9244695",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0639\u0646\u0627\u0628\u0629"
     ],
     "name:eng_x_preferred":[
+        "Annaba"
+    ],
+    "name:eng_x_variant":[
         "Annaba Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189563,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Annaba Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Annaba",
     "wof:parent_id":85670713,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/563/421189563.geojson
+++ b/data/421/189/563/421189563.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0639\u0646\u0627\u0628\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Annaba Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189563,
-    "wof:lastmodified":1566583491,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0639\u0646\u0627\u0628\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Annaba Province",
     "wof:parent_id":85670713,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/565/421189565.geojson
+++ b/data/421/189/565/421189565.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.765291,
     "geom:longitude":5.07808,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Bejaia Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"5.05808,36.745291,5.09808,36.785291",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0628\u062c\u0627\u064a\u0629"
     ],
     "name:eng_x_preferred":[
+        "Bejaia"
+    ],
+    "name:eng_x_variant":[
         "Bejaia Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189565,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Bejaia Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Bejaia",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/565/421189565.geojson
+++ b/data/421/189/565/421189565.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":36.765291,
     "geom:longitude":5.07808,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Bejaia Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"5.05808,36.745291,5.09808,36.785291",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189565,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423087,
     "wof:name":"Bejaia",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/189/565/421189565.geojson
+++ b/data/421/189/565/421189565.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0628\u062c\u0627\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Bejaia Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189565,
-    "wof:lastmodified":1566583492,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0628\u062c\u0627\u064a\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Bejaia Province",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/567/421189567.geojson
+++ b/data/421/189/567/421189567.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0628\u0644\u064a\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Blida Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189567,
-    "wof:lastmodified":1566583491,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0628\u0644\u064a\u062f\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Blida Province",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/567/421189567.geojson
+++ b/data/421/189/567/421189567.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":36.480499,
     "geom:longitude":2.829566,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Blida Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"2.809566,36.460499,2.849566,36.500499",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189567,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423088,
     "wof:name":"Blida",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/189/567/421189567.geojson
+++ b/data/421/189/567/421189567.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.480499,
     "geom:longitude":2.829566,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Blida Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"2.809566,36.460499,2.849566,36.500499",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0628\u0644\u064a\u062f\u0629"
     ],
     "name:eng_x_preferred":[
+        "Blida"
+    ],
+    "name:eng_x_variant":[
         "Blida Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189567,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Blida Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Blida",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/571/421189571.geojson
+++ b/data/421/189/571/421189571.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.065543,
     "geom:longitude":4.817504,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Bordj Bou Arreidj Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"4.797504,36.045543,4.837504,36.085543",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c"
     ],
     "name:eng_x_preferred":[
+        "Bordj Bou Arreidj"
+    ],
+    "name:eng_x_variant":[
         "Bordj Bou Arreidj Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189571,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Bordj Bou Arreidj Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Bordj Bou Arreidj",
     "wof:parent_id":85670809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/571/421189571.geojson
+++ b/data/421/189/571/421189571.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c"
+    ],
+    "name:eng_x_preferred":[
+        "Bordj Bou Arreidj Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189571,
-    "wof:lastmodified":1566583492,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Bordj Bou Arreidj Province",
     "wof:parent_id":85670809,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/571/421189571.geojson
+++ b/data/421/189/571/421189571.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":36.065543,
     "geom:longitude":4.817504,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Bordj Bou Arreidj Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"4.797504,36.045543,4.837504,36.085543",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189571,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bordj Bou Arreidj",
     "wof:parent_id":85670809,
     "wof:placetype":"locality",

--- a/data/421/189/573/421189573.geojson
+++ b/data/421/189/573/421189573.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0642\u0633\u0646\u0637\u064a\u0646\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Constanine Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189573,
-    "wof:lastmodified":1566583491,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0642\u0633\u0646\u0637\u064a\u0646\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Constanine Province",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/573/421189573.geojson
+++ b/data/421/189/573/421189573.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":36.364321,
     "geom:longitude":6.609449,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Constanine Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"6.589449,36.344321,6.629449,36.384321",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189573,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423088,
     "wof:name":"Constanine",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",

--- a/data/421/189/573/421189573.geojson
+++ b/data/421/189/573/421189573.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.364321,
     "geom:longitude":6.609449,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Constanine Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"6.589449,36.344321,6.629449,36.384321",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0642\u0633\u0646\u0637\u064a\u0646\u0629"
     ],
     "name:eng_x_preferred":[
+        "Constanine"
+    ],
+    "name:eng_x_variant":[
         "Constanine Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189573,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Constanine Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Constanine",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/575/421189575.geojson
+++ b/data/421/189/575/421189575.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":35.939031,
     "geom:longitude":0.086689,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Mostaganem Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"0.0666885,35.9190305,0.1066885,35.9590305",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0645\u0633\u062a\u063a\u0627\u0646\u0645"
     ],
     "name:eng_x_preferred":[
+        "Mostaganem"
+    ],
+    "name:eng_x_variant":[
         "Mostaganem Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189575,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Mostaganem Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Mostaganem",
     "wof:parent_id":85670787,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/575/421189575.geojson
+++ b/data/421/189/575/421189575.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0645\u0633\u062a\u063a\u0627\u0646\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Mostaganem Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189575,
-    "wof:lastmodified":1566583491,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0645\u0633\u062a\u063a\u0627\u0646\u0645",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Mostaganem Province",
     "wof:parent_id":85670787,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/575/421189575.geojson
+++ b/data/421/189/575/421189575.geojson
@@ -6,16 +6,10 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0866885,35.9390305,0.0866885,35.9390305",
+    "geom:bbox":"0.086689,35.939031,0.086689,35.939031",
     "geom:latitude":35.939031,
     "geom:longitude":0.086689,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Mostaganem Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"0.0666885,35.9190305,0.1066885,35.9590305",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -63,7 +57,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1459009629,
-    "wof:geomhash":"3f204a9645e82e270226f61671c5dc5a",
+    "wof:geomhash":"675a690cd6a281793d1a457c4eef9a81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189575,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423091,
     "wof:name":"Mostaganem",
     "wof:parent_id":85670787,
     "wof:placetype":"locality",
@@ -83,10 +77,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    0.0866885,
-    35.9390305,
-    0.0866885,
-    35.9390305
+    0.086689,
+    35.939031,
+    0.086689,
+    35.939031
 ],
-  "geometry": {"coordinates":[0.0866885,35.9390305],"type":"Point"}
+  "geometry": {"coordinates":[0.086689,35.939031],"type":"Point"}
 }

--- a/data/421/189/577/421189577.geojson
+++ b/data/421/189/577/421189577.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.827424,
     "geom:longitude":5.768852,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Jijel Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"5.748852,36.807424,5.788852,36.847424",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u062c\u064a\u062c\u0644"
     ],
     "name:eng_x_preferred":[
+        "Jijel"
+    ],
+    "name:eng_x_variant":[
         "Jijel Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189577,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Jijel Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Jijel",
     "wof:parent_id":85670723,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/577/421189577.geojson
+++ b/data/421/189/577/421189577.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":36.827424,
     "geom:longitude":5.768852,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Jijel Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"5.748852,36.807424,5.788852,36.847424",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189577,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423089,
     "wof:name":"Jijel",
     "wof:parent_id":85670723,
     "wof:placetype":"locality",

--- a/data/421/189/577/421189577.geojson
+++ b/data/421/189/577/421189577.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u062c\u064a\u062c\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Jijel Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189577,
-    "wof:lastmodified":1566583492,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u062c\u064a\u062c\u0644",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Jijel Province",
     "wof:parent_id":85670723,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/579/421189579.geojson
+++ b/data/421/189/579/421189579.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.26926,
     "geom:longitude":2.748405,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Medea Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"2.728405,36.24926,2.768405,36.28926",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0645\u062f\u064a\u0629"
     ],
     "name:eng_x_preferred":[
+        "Medea"
+    ],
+    "name:eng_x_variant":[
         "Medea Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189579,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Medea Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Medea",
     "wof:parent_id":85670837,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/579/421189579.geojson
+++ b/data/421/189/579/421189579.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0645\u062f\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Medea Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189579,
-    "wof:lastmodified":1566583492,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0645\u062f\u064a\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Medea Province",
     "wof:parent_id":85670837,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/579/421189579.geojson
+++ b/data/421/189/579/421189579.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":36.26926,
     "geom:longitude":2.748405,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Medea Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"2.728405,36.24926,2.768405,36.28926",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189579,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423090,
     "wof:name":"Medea",
     "wof:parent_id":85670837,
     "wof:placetype":"locality",

--- a/data/421/189/581/421189581.geojson
+++ b/data/421/189/581/421189581.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u062a\u0645\u0646\u0631\u0627\u0633\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Tamanrasset Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189581,
-    "wof:lastmodified":1566583491,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u062a\u0645\u0646\u0631\u0627\u0633\u062a",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Tamanrasset Province",
     "wof:parent_id":85670735,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/581/421189581.geojson
+++ b/data/421/189/581/421189581.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":22.78969,
     "geom:longitude":5.524406,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Tamanrasset Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"5.504406,22.76969,5.544406,22.80969",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u062a\u0645\u0646\u0631\u0627\u0633\u062a"
     ],
     "name:eng_x_preferred":[
+        "Tamanrasset"
+    ],
+    "name:eng_x_variant":[
         "Tamanrasset Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189581,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Tamanrasset Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Tamanrasset",
     "wof:parent_id":85670735,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/581/421189581.geojson
+++ b/data/421/189/581/421189581.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":22.78969,
     "geom:longitude":5.524406,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Tamanrasset Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"5.504406,22.76969,5.544406,22.80969",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189581,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tamanrasset",
     "wof:parent_id":85670735,
     "wof:placetype":"locality",

--- a/data/421/189/583/421189583.geojson
+++ b/data/421/189/583/421189583.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":36.587276,
     "geom:longitude":2.446583,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Tipaza Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"2.426583,36.567276,2.466583,36.607276",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189583,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tipaza",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/189/583/421189583.geojson
+++ b/data/421/189/583/421189583.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.587276,
     "geom:longitude":2.446583,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Tipaza Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"2.426583,36.567276,2.466583,36.607276",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u062a\u064a\u0628\u0627\u0632\u0629"
     ],
     "name:eng_x_preferred":[
+        "Tipaza"
+    ],
+    "name:eng_x_variant":[
         "Tipaza Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189583,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Tipaza Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Tipaza",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/583/421189583.geojson
+++ b/data/421/189/583/421189583.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u062a\u064a\u0628\u0627\u0632\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Tipaza Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189583,
-    "wof:lastmodified":1566583492,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u062a\u064a\u0628\u0627\u0632\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Tipaza Province",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/585/421189585.geojson
+++ b/data/421/189/585/421189585.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":36.721342,
     "geom:longitude":4.045801,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Tizi Ouzou Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"4.025801,36.701342,4.065801,36.741342",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u062a\u064a\u0632\u064a \u0648\u0632\u0648"
     ],
     "name:eng_x_preferred":[
+        "Tizi Ouzou"
+    ],
+    "name:eng_x_variant":[
         "Tizi Ouzou Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189585,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Tizi Ouzou Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Tizi Ouzou",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/585/421189585.geojson
+++ b/data/421/189/585/421189585.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u062a\u064a\u0632\u064a \u0648\u0632\u0648"
+    ],
+    "name:eng_x_preferred":[
+        "Tizi Ouzou Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189585,
-    "wof:lastmodified":1566583492,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u062a\u064a\u0632\u064a \u0648\u0632\u0648",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Tizi Ouzou Province",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/585/421189585.geojson
+++ b/data/421/189/585/421189585.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":36.721342,
     "geom:longitude":4.045801,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Tizi Ouzou Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"4.025801,36.701342,4.065801,36.741342",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189585,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tizi Ouzou",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/189/589/421189589.geojson
+++ b/data/421/189/589/421189589.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":34.879945,
     "geom:longitude":-1.31393,
     "iso:country":"DZ",
+    "label:eng_x_preferred_longname":[
+        "Tlemcen Province"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "province"
+    ],
     "lbl:bbox":"-1.33393,34.8599455,-1.29393,34.8999455",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0648\u0644\u0627\u064a\u0629 \u062a\u0644\u0645\u0633\u0627\u0646"
     ],
     "name:eng_x_preferred":[
+        "Tlemcen"
+    ],
+    "name:eng_x_variant":[
         "Tlemcen Province"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421189589,
-    "wof:lastmodified":1601068401,
-    "wof:name":"Tlemcen Province",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Tlemcen",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",

--- a/data/421/189/589/421189589.geojson
+++ b/data/421/189/589/421189589.geojson
@@ -6,16 +6,10 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-1.31393,34.8799455,-1.31393,34.8799455",
+    "geom:bbox":"-1.31393,34.879945,-1.31393,34.879945",
     "geom:latitude":34.879945,
     "geom:longitude":-1.31393,
     "iso:country":"DZ",
-    "label:eng_x_preferred_longname":[
-        "Tlemcen Province"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "province"
-    ],
     "lbl:bbox":"-1.33393,34.8599455,-1.29393,34.8999455",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -63,7 +57,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1459009629,
-    "wof:geomhash":"00d79cde57e0cdf19ee3892fbc226f06",
+    "wof:geomhash":"708e5b7aef21bcd5b904e28d6049a428",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -73,7 +67,7 @@
         }
     ],
     "wof:id":421189589,
-    "wof:lastmodified":1601337573,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tlemcen",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",
@@ -84,9 +78,9 @@
 },
   "bbox": [
     -1.31393,
-    34.8799455,
+    34.879945,
     -1.31393,
-    34.8799455
+    34.879945
 ],
-  "geometry": {"coordinates":[-1.31393,34.8799455],"type":"Point"}
+  "geometry": {"coordinates":[-1.31393,34.879945],"type":"Point"}
 }

--- a/data/421/189/589/421189589.geojson
+++ b/data/421/189/589/421189589.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u062a\u0644\u0645\u0633\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Tlemcen Province"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189589,
-    "wof:lastmodified":1566583491,
-    "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u062a\u0644\u0645\u0633\u0627\u0646",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Tlemcen Province",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-dz",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.