### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/521/679/102521679.geojson
+++ b/data/102/521/679/102521679.geojson
@@ -22,8 +22,14 @@
     "name:ast_x_preferred":[
         "Aeropuertu Internacional Mohamed Boudiaf"
     ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Rhyngwladol Mohamed Boudiaf"
+    ],
     "name:deu_x_preferred":[
         "Flughafen Constantine"
+    ],
+    "name:ell_x_preferred":[
+        "\u0394\u03b9\u03b5\u03b8\u03bd\u03ad\u03c2 \u0391\u03b5\u03c1\u03bf\u03b4\u03c1\u03cc\u03bc\u03b9\u03bf \u039c\u03bf\u03c7\u03ac\u03bc\u03b5\u03bd\u03c4 \u039c\u03c0\u03bf\u03c5\u03bd\u03c4\u03b9\u03ac\u03c6"
     ],
     "name:eng_x_preferred":[
         "Mohamed Boudiaf International Airport"
@@ -40,6 +46,9 @@
     ],
     "name:glg_x_preferred":[
         "Aeroporto Mohamed Boudiaf"
+    ],
+    "name:hun_x_preferred":[
+        "Kaszent\u00ednai nemzetk\u00f6zi rep\u00fcl\u0151t\u00e9r"
     ],
     "name:ind_x_preferred":[
         "Bandar Udara Internasional Mohamed Boudiaf"
@@ -70,6 +79,9 @@
     ],
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0431\u0438\u043d\u200c\u0430\u043b\u043c\u0438\u043b\u0430\u043b\u04e3 \u043c\u0443\u04b3\u0430\u043c\u043c\u0430\u0434 \u0431\u0443\u0437\u0438\u043e\u0444"
+    ],
+    "name:tur_x_preferred":[
+        "Konstantin Muhammed Budiaf Havaliman\u0131"
     ],
     "name:vie_x_preferred":[
         "S\u00e2n bay qu\u1ed1c t\u1ebf Mohamed Boudiaf"
@@ -111,7 +123,7 @@
         }
     ],
     "wof:id":102521679,
-    "wof:lastmodified":1566582799,
+    "wof:lastmodified":1690875488,
     "wof:name":"Ain El Bey Airport",
     "wof:parent_id":85670855,
     "wof:placetype":"campus",

--- a/data/102/521/765/102521765.geojson
+++ b/data/102/521/765/102521765.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:cym_x_preferred":[
+        "Maes Awyr A\u00efn Oussera"
+    ],
     "name:eng_x_preferred":[
         "A\u00efn Oussera Airport"
     ],
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":102521765,
-    "wof:lastmodified":1631750771,
+    "wof:lastmodified":1690875487,
     "wof:name":"Ain Oussera Airport",
     "wof:parent_id":85670833,
     "wof:placetype":"campus",

--- a/data/102/521/785/102521785.geojson
+++ b/data/102/521/785/102521785.geojson
@@ -32,6 +32,9 @@
     "name:ind_x_preferred":[
         "Bandar Udara Mecheria"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e1\u30b7\u30a7\u30ea\u30a2\u7a7a\u6e2f"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Mecheria"
     ],
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":102521785,
-    "wof:lastmodified":1631750771,
+    "wof:lastmodified":1690875487,
     "wof:name":"Mecheria Airport",
     "wof:parent_id":85670707,
     "wof:placetype":"campus",

--- a/data/112/576/475/9/1125764759.geojson
+++ b/data/112/576/475/9/1125764759.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0645\u0647\u0631\u0629 \u0623\u062d\u0645\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0645\u0647\u0631\u0647 \u0627\u062d\u0645\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u0645\u0647\u0631\u0647 \u0627\u062d\u0645\u062f"
     ],
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":1125764759,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1690875564,
     "wof:name":"Boumahra Ahmed",
     "wof:parent_id":85670857,
     "wof:placetype":"locality",

--- a/data/112/576/851/7/1125768517.geojson
+++ b/data/112/576/851/7/1125768517.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0628\u0633\u0628\u0633\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0628\u0633\u0628\u0633\u062a"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0628\u0633\u0628\u0633\u062a"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Tebesbest"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c6\u30d9\u30b9\u30d9\u30b9\u30c8"
     ],
     "name:msa_x_preferred":[
         "Tebesbest"
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":1125768517,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1690875563,
     "wof:name":"Tebesbest",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",

--- a/data/112/578/875/9/1125788759.geojson
+++ b/data/112/578/875/9/1125788759.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0623\u063a\u0631\u064a\u0628"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u063a\u0631\u064a\u0628"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u063a\u0631\u06cc\u0628"
+    ],
+    "name:cat_x_preferred":[
+        "Aghrib"
     ],
     "name:ceb_x_preferred":[
         "Arhribs"
@@ -79,6 +85,9 @@
     "name:zho_x_preferred":[
         "\u963f\u683c\u91cc\u535c"
     ],
+    "name:zul_x_preferred":[
+        "Aghrib"
+    ],
     "qs_pg:aaroncc":"DZ",
     "qs_pg:gn_country":"DZ",
     "qs_pg:gn_fcode":"PPL",
@@ -116,7 +125,7 @@
         }
     ],
     "wof:id":1125788759,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1690875564,
     "wof:name":"Arhribs",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/112/588/171/5/1125881715.geojson
+++ b/data/112/588/171/5/1125881715.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0639\u0645\u064a \u0645\u0648\u0633\u0649"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u0645\u0649 \u0645\u0648\u0633\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0645\u06cc \u0645\u0648\u0633\u06cc"
     ],
@@ -46,6 +49,9 @@
     "name:ita_x_preferred":[
         "Ammi Moussa"
     ],
+    "name:kab_x_preferred":[
+        "\u0190emmi Musa"
+    ],
     "name:msa_x_preferred":[
         "Ammi Moussa"
     ],
@@ -65,6 +71,9 @@
         "Ammi Moussa"
     ],
     "name:swe_x_preferred":[
+        "Ammi Moussa"
+    ],
+    "name:uzb_x_preferred":[
         "Ammi Moussa"
     ],
     "name:vie_x_preferred":[
@@ -110,7 +119,7 @@
         }
     ],
     "wof:id":1125881715,
-    "wof:lastmodified":1566583520,
+    "wof:lastmodified":1690875558,
     "wof:name":"Ammi Moussa",
     "wof:parent_id":85670791,
     "wof:placetype":"locality",

--- a/data/112/588/172/9/1125881729.geojson
+++ b/data/112/588/172/9/1125881729.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a \u0639\u0645\u0631\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u0649 \u0639\u0645\u0631\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc \u0639\u0645\u0631\u0627\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "B\u0259ni-\u018fmran"
     ],
     "name:ceb_x_preferred":[
         "Beni Amrane"
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":1125881729,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875558,
     "wof:name":"Beni Amrane",
     "wof:parent_id":85670823,
     "wof:placetype":"locality",

--- a/data/112/588/174/1/1125881741.geojson
+++ b/data/112/588/174/1/1125881741.geojson
@@ -31,6 +31,9 @@
     "name:azb_x_preferred":[
         "\u0628\u0631\u06cc\u06a9\u0647"
     ],
+    "name:aze_x_preferred":[
+        "B\u0259rik\u0259"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09b0\u09be\u09bf\u0995\u09be"
     ],
@@ -38,6 +41,9 @@
         "Barika"
     ],
     "name:dan_x_preferred":[
+        "Barika"
+    ],
+    "name:deu_x_preferred":[
         "Barika"
     ],
     "name:ell_x_preferred":[
@@ -109,6 +115,9 @@
     "name:por_x_preferred":[
         "Barika"
     ],
+    "name:pus_x_preferred":[
+        "\u0628\u0631\u064a\u06a9\u0647"
+    ],
     "name:ron_x_preferred":[
         "Barika"
     ],
@@ -119,6 +128,9 @@
         "\u0db6\u0dbb\u0dd2\u0d9a\u0dcf"
     ],
     "name:spa_x_preferred":[
+        "Barika"
+    ],
+    "name:swa_x_preferred":[
         "Barika"
     ],
     "name:swe_x_preferred":[
@@ -188,7 +200,7 @@
         }
     ],
     "wof:id":1125881741,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875558,
     "wof:name":"Barika",
     "wof:parent_id":85670851,
     "wof:placetype":"locality",

--- a/data/112/589/319/7/1125893197.geojson
+++ b/data/112/589/319/7/1125893197.geojson
@@ -25,11 +25,20 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u0628\u0631\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0628\u0631\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0627\u0644\u0628\u0631\u062f"
     ],
+    "name:ceb_x_preferred":[
+        "'A\u00efn el Berd"
+    ],
     "name:eng_x_preferred":[
         "A\u00efn El Berd"
+    ],
+    "name:eng_x_variant":[
+        "Ain El Berd"
     ],
     "name:fas_x_preferred":[
         "\u0639\u06cc\u0646 \u0627\u0644\u0628\u0631\u062f"
@@ -39,6 +48,9 @@
     ],
     "name:ita_x_preferred":[
         "A\u00efn El Berd"
+    ],
+    "name:kab_x_preferred":[
+        "\u0190in Lberd"
     ],
     "name:msa_x_preferred":[
         "Ain El Berd"
@@ -60,6 +72,9 @@
     ],
     "name:spa_x_preferred":[
         "A\u00efn El Berd"
+    ],
+    "name:swe_x_preferred":[
+        "'A\u00efn el Berd"
     ],
     "name:und_x_variant":[
         "Oued Imbert"
@@ -104,7 +119,7 @@
         }
     ],
     "wof:id":1125893197,
-    "wof:lastmodified":1566583520,
+    "wof:lastmodified":1690875559,
     "wof:name":"\u2019A\u00efn el Berd",
     "wof:parent_id":85670691,
     "wof:placetype":"locality",

--- a/data/112/589/320/9/1125893209.geojson
+++ b/data/112/589/320/9/1125893209.geojson
@@ -25,14 +25,26 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u0627\u0628\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0627\u0628\u0644"
+    ],
     "name:ceb_x_preferred":[
         "'A\u00efn el Bell"
     ],
     "name:eng_x_preferred":[
         "A\u00efn El Ibel"
     ],
+    "name:fas_x_preferred":[
+        "\u0639\u06cc\u0646 \u0627\u0644\u0627\u0628\u0644"
+    ],
     "name:fra_x_preferred":[
         "A\u00efn El Ibel"
+    ],
+    "name:ita_x_preferred":[
+        "A\u00efn El Ibel"
+    ],
+    "name:kab_x_preferred":[
+        "\u0190in Libil"
     ],
     "name:msa_x_preferred":[
         "A\u00efn El Ibel"
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":1125893209,
-    "wof:lastmodified":1566583520,
+    "wof:lastmodified":1690875559,
     "wof:name":"\u2019A\u00efn el Bell",
     "wof:parent_id":85670833,
     "wof:placetype":"locality",

--- a/data/112/591/486/1/1125914861.geojson
+++ b/data/112/591/486/1/1125914861.geojson
@@ -25,14 +25,23 @@
     "name:ara_x_preferred":[
         "\u0633\u0648\u0631 \u0627\u0644\u063a\u0632\u0644\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0648\u0631 \u0627\u0644\u063a\u0632\u0644\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0648\u0631 \u0627\u0644\u063a\u0632\u0644\u0627\u0646"
+    ],
+    "name:cat_x_preferred":[
+        "Sour El-Ghozlane"
     ],
     "name:ceb_x_preferred":[
         "Sour el Ghozlane"
     ],
     "name:deu_x_preferred":[
         "Sour El-Ghozlane"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03bf\u03c5\u03c1 \u0395\u03bb \u0393\u03ba\u03bf\u03b6\u03bb\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Sour El-Ghozlane"
@@ -82,6 +91,12 @@
     "name:vie_x_preferred":[
         "Sour El Ghouzlane"
     ],
+    "name:zho_x_preferred":[
+        "\u82cf\u5c14\u53e4\u5179\u5170"
+    ],
+    "name:zul_x_preferred":[
+        "Sour El-Ghouzlane"
+    ],
     "qs_pg:aaroncc":"DZ",
     "qs_pg:gn_country":"DZ",
     "qs_pg:gn_fcode":"PPL",
@@ -119,7 +134,7 @@
         }
     ],
     "wof:id":1125914861,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875562,
     "wof:name":"Sour el Ghozlane",
     "wof:parent_id":85670823,
     "wof:placetype":"locality",

--- a/data/112/591/486/5/1125914865.geojson
+++ b/data/112/591/486/5/1125914865.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0633\u0648\u0642\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0633\u0648\u0642\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0648\u0642\u0631"
     ],
@@ -82,6 +85,9 @@
     "name:zho_x_preferred":[
         "\u8607\u683c\u723e"
     ],
+    "name:zul_x_preferred":[
+        "Sougueur"
+    ],
     "qs_pg:aaroncc":"DZ",
     "qs_pg:gn_country":"DZ",
     "qs_pg:gn_fcode":"PPL",
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":1125914865,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875562,
     "wof:name":"Sougueur",
     "wof:parent_id":85670801,
     "wof:placetype":"locality",

--- a/data/112/591/488/1/1125914881.geojson
+++ b/data/112/591/488/1/1125914881.geojson
@@ -28,11 +28,23 @@
     "name:ara_x_variant":[
         "\u0633\u064a\u062f\u064a \u0639\u0642\u0628\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0639\u0642\u0628\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Sidi-\u018fqb\u0259"
+    ],
     "name:cat_x_preferred":[
         "Sidi Okba"
     ],
     "name:ceb_x_preferred":[
         "Sidi Okba"
+    ],
+    "name:dan_x_preferred":[
+        "Sidi Okba"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b9\u03bd\u03c4\u03af \u039f\u03ba\u03bc\u03c0\u03ac"
     ],
     "name:eng_x_preferred":[
         "Sidi Okba"
@@ -70,10 +82,16 @@
     "name:swe_x_preferred":[
         "Sidi Okba"
     ],
+    "name:tur_x_preferred":[
+        "Sidi Ukbe"
+    ],
     "name:urd_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0639\u0642\u0628\u06c1"
     ],
     "name:vie_x_preferred":[
+        "Sidi Okba"
+    ],
+    "name:zul_x_preferred":[
         "Sidi Okba"
     ],
     "qs_pg:aaroncc":"DZ",
@@ -113,7 +131,7 @@
         }
     ],
     "wof:id":1125914881,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875562,
     "wof:name":"Sidi Okba",
     "wof:parent_id":85670827,
     "wof:placetype":"locality",

--- a/data/112/591/504/7/1125915047.geojson
+++ b/data/112/591/504/7/1125915047.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u0645\u0648\u0633\u0649"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0645\u0648\u0633\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Sidi Moussa"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "Sidi Moussa"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30c7\u30a3\u30fb\u30e0\u30b5"
     ],
     "name:kab_x_preferred":[
         "Sidi Musa"
@@ -63,6 +69,9 @@
     ],
     "name:swe_x_preferred":[
         "Sidi Moussa"
+    ],
+    "name:tur_x_preferred":[
+        "Sidi Musa"
     ],
     "name:urd_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0645\u0648\u0633\u06cc\u060c \u0627\u0644\u062c\u0632\u0627\u0626\u0631"
@@ -110,7 +119,7 @@
         }
     ],
     "wof:id":1125915047,
-    "wof:lastmodified":1566583520,
+    "wof:lastmodified":1690875559,
     "wof:name":"Sidi Moussa",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/112/591/506/1/1125915061.geojson
+++ b/data/112/591/506/1/1125915061.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u0639\u0643\u0627\u0634\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0639\u0643\u0627\u0634\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0639\u06a9\u0627\u0634\u0647"
     ],
@@ -79,6 +82,9 @@
     "name:zho_x_preferred":[
         "\u897f\u8fea\u963f\u5361\u6c99"
     ],
+    "name:zul_x_preferred":[
+        "Sidi Akkacha"
+    ],
     "qs_pg:aaroncc":"DZ",
     "qs_pg:gn_country":"DZ",
     "qs_pg:gn_fcode":"PPL",
@@ -116,7 +122,7 @@
         }
     ],
     "wof:id":1125915061,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875561,
     "wof:name":"Sidi Akkacha",
     "wof:parent_id":85670781,
     "wof:placetype":"locality",

--- a/data/112/591/507/7/1125915077.geojson
+++ b/data/112/591/507/7/1125915077.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u0627\u0644\u0639\u0628\u062f\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0627\u0644\u0639\u0628\u062f\u0644\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0639\u0628\u062f\u0644\u06cc"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Sidi Abdelli"
+    ],
+    "name:kab_x_preferred":[
+        "Sidi \u0190ebdelli"
     ],
     "name:msa_x_preferred":[
         "Sidi Abdelli"
@@ -70,7 +76,13 @@
     "name:und_x_variant":[
         "Les Abdellys"
     ],
+    "name:uzb_x_preferred":[
+        "Sidi Abdelli"
+    ],
     "name:vie_x_preferred":[
+        "Sidi Abdelli"
+    ],
+    "name:zul_x_preferred":[
         "Sidi Abdelli"
     ],
     "qs_pg:aaroncc":"DZ",
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":1125915077,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875561,
     "wof:name":"Sidi Abdelli",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/112/591/509/9/1125915099.geojson
+++ b/data/112/591/509/9/1125915099.geojson
@@ -25,8 +25,17 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u062f\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u062f\u064a\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "M\u00e9d\u00e9a"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0645\u062f\u06cc\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "M\u0259diya"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09c7\u09a6\u09bf\u09af\u09bc\u09be"
@@ -88,6 +97,9 @@
     "name:kab_x_preferred":[
         "Lemdiyyet"
     ],
+    "name:kab_x_variant":[
+        "Lemdeyya"
+    ],
     "name:kan_x_preferred":[
         "\u0cae\u0cc6\u0ca1\u0cbf\u0caf\u0cbe"
     ],
@@ -137,6 +149,9 @@
         "\u0db8\u0dd9\u0daf\u0dd2\u0dba\u0dcf"
     ],
     "name:spa_x_preferred":[
+        "M\u00e9d\u00e9a"
+    ],
+    "name:swa_x_preferred":[
         "M\u00e9d\u00e9a"
     ],
     "name:swe_x_preferred":[
@@ -212,7 +227,7 @@
         }
     ],
     "wof:id":1125915099,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875561,
     "wof:name":"M\u00e9d\u00e9a",
     "wof:parent_id":85670837,
     "wof:placetype":"locality",

--- a/data/112/591/511/3/1125915113.geojson
+++ b/data/112/591/511/3/1125915113.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0646\u062f\u0631\u0648\u0645\u0629"
     ],
+    "name:arq_x_preferred":[
+        "\u0646\u062f\u0631\u0648\u0645\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0646\u062f\u0631\u0648\u0645\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u062f\u0631\u0648\u0645\u0647"
     ],
@@ -52,6 +58,9 @@
     "name:kab_x_preferred":[
         "Nadruma"
     ],
+    "name:kab_x_variant":[
+        "Nedruma"
+    ],
     "name:msa_x_preferred":[
         "Nedroma"
     ],
@@ -76,7 +85,19 @@
     "name:swe_x_preferred":[
         "Nedroma"
     ],
+    "name:urd_x_preferred":[
+        "\u0646\u062f\u0631\u0648\u0645\u06c1"
+    ],
+    "name:uzb_x_preferred":[
+        "Nedroma"
+    ],
     "name:vie_x_preferred":[
+        "Nedroma"
+    ],
+    "name:zho_x_preferred":[
+        "\u5167\u5fb7\u7f85\u99ac"
+    ],
+    "name:zul_x_preferred":[
         "Nedroma"
     ],
     "qs_pg:aaroncc":"DZ",
@@ -116,7 +137,7 @@
         }
     ],
     "wof:id":1125915113,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875561,
     "wof:name":"Nedroma",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/112/591/512/1/1125915121.geojson
+++ b/data/112/591/512/1/1125915121.geojson
@@ -28,8 +28,14 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0646\u0627\u0635\u0631\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0646\u0627\u0635\u0631\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u0627\u0635\u0631\u06cc\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Nasiriyy\u0259"
     ],
     "name:ceb_x_preferred":[
         "Naciria"
@@ -42,6 +48,9 @@
     ],
     "name:fra_x_preferred":[
         "Naciria"
+    ],
+    "name:hye_x_preferred":[
+        "\u0546\u0561\u057d\u056b\u0580\u056b\u0561"
     ],
     "name:ita_x_preferred":[
         "Naciria"
@@ -119,7 +128,7 @@
         }
     ],
     "wof:id":1125915121,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875562,
     "wof:name":"Naciria",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/112/591/515/7/1125915157.geojson
+++ b/data/112/591/515/7/1125915157.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0642\u0627\u0644\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0627\u0644\u0645\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0627\u0644\u0645\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Qelma"
     ],
     "name:bel_x_preferred":[
         "\u0413\u0435\u043b\u044c\u043c\u0430"
@@ -51,6 +57,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03ba\u03ad\u03bb\u03bc\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0393\u03ba\u03b5\u03bb\u03bc\u03ac"
     ],
     "name:eng_x_preferred":[
         "Guelma"
@@ -151,6 +160,9 @@
     "name:spa_x_preferred":[
         "Guelma"
     ],
+    "name:swa_x_preferred":[
+        "Guelma"
+    ],
     "name:swe_x_preferred":[
         "Guelma"
     ],
@@ -218,7 +230,7 @@
         }
     ],
     "wof:id":1125915157,
-    "wof:lastmodified":1636501723,
+    "wof:lastmodified":1690875562,
     "wof:name":"Guelma",
     "wof:parent_id":85670857,
     "wof:placetype":"locality",

--- a/data/112/591/518/9/1125915189.geojson
+++ b/data/112/591/518/9/1125915189.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0623\u062e\u0636\u0631\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0627\u062e\u0636\u0631\u064a\u0647"
+    ],
     "name:ceb_x_preferred":[
         "Lakhdaria"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:kab_x_preferred":[
         "Lex\u1e0dareyya"
+    ],
+    "name:kab_x_variant":[
+        "At Ulmu"
     ],
     "name:msa_x_preferred":[
         "Lakhdaria"
@@ -77,6 +83,9 @@
         "Palestro"
     ],
     "name:vie_x_preferred":[
+        "Lakhdaria"
+    ],
+    "name:zul_x_preferred":[
         "Lakhdaria"
     ],
     "qs_pg:aaroncc":"DZ",
@@ -116,7 +125,7 @@
         }
     ],
     "wof:id":1125915189,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875560,
     "wof:name":"Lakhdaria",
     "wof:parent_id":85670823,
     "wof:placetype":"locality",

--- a/data/112/591/519/5/1125915195.geojson
+++ b/data/112/591/519/5/1125915195.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0642\u0635\u0631 \u0627\u0644\u0634\u0644\u0627\u0644\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0635\u0631 \u0627\u0644\u0634\u0644\u0627\u0644\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0635\u0631 \u0634\u0644\u0627\u0644\u0647"
     ],
@@ -73,6 +76,9 @@
     "name:vie_x_preferred":[
         "Ksar Chellala"
     ],
+    "name:zul_x_preferred":[
+        "Ksar Chellala"
+    ],
     "qs_pg:aaroncc":"DZ",
     "qs_pg:gn_country":"DZ",
     "qs_pg:gn_fcode":"PPL",
@@ -110,7 +116,7 @@
         }
     ],
     "wof:id":1125915195,
-    "wof:lastmodified":1566583521,
+    "wof:lastmodified":1690875560,
     "wof:name":"Ksar Chellala",
     "wof:parent_id":85670801,
     "wof:placetype":"locality",

--- a/data/112/591/526/7/1125915267.geojson
+++ b/data/112/591/526/7/1125915267.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u062a\u0644\u064a\u0644\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u062a\u0644\u064a\u0644\u064a\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u062a\u0644\u06cc\u0644\u06cc\u0633"
+    ],
+    "name:ceb_x_preferred":[
+        "Bou Tlelis"
     ],
     "name:eng_x_preferred":[
         "Boutl\u00e9lis"
@@ -59,6 +65,12 @@
         "Boutlelis"
     ],
     "name:spa_x_preferred":[
+        "Boutl\u00e9lis"
+    ],
+    "name:swe_x_preferred":[
+        "Bou Tlelis"
+    ],
+    "name:uzb_x_preferred":[
         "Boutl\u00e9lis"
     ],
     "name:vie_x_preferred":[
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":1125915267,
-    "wof:lastmodified":1566583520,
+    "wof:lastmodified":1690875560,
     "wof:name":"Bou Tlelis",
     "wof:parent_id":85670689,
     "wof:placetype":"locality",

--- a/data/112/591/528/7/1125915287.geojson
+++ b/data/112/591/528/7/1125915287.geojson
@@ -25,8 +25,20 @@
     "name:ara_x_preferred":[
         "\u0628\u0634\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0634\u0627\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "B\u00e9char"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0634\u0627\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "B\u0259\u015far"
+    ],
+    "name:bel_x_preferred":[
+        "\u0411\u0435\u0448\u0430\u0440"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u0995\u09b9\u09be\u09b0"
@@ -130,6 +142,9 @@
     "name:por_x_preferred":[
         "B\u00e9char"
     ],
+    "name:pus_x_preferred":[
+        "\u0628\u0634\u0627\u0631"
+    ],
     "name:ron_x_preferred":[
         "Bechar"
     ],
@@ -153,6 +168,9 @@
     ],
     "name:sqi_x_preferred":[
         "Bechar"
+    ],
+    "name:swa_x_preferred":[
+        "B\u00e9char"
     ],
     "name:swe_x_preferred":[
         "B\u00e9char"
@@ -189,6 +207,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8d1d\u6c99\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9char"
     ],
     "qs_pg:aaroncc":"DZ",
     "qs_pg:gn_country":"DZ",
@@ -227,7 +248,7 @@
         }
     ],
     "wof:id":1125915287,
-    "wof:lastmodified":1566583520,
+    "wof:lastmodified":1690875560,
     "wof:name":"B\u00e9char",
     "wof:parent_id":85670699,
     "wof:placetype":"locality",

--- a/data/112/595/901/9/1125959019.geojson
+++ b/data/112/595/901/9/1125959019.geojson
@@ -25,8 +25,20 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062b\u0646\u064a\u0629"
     ],
+    "name:arq_x_preferred":[
+        "\u0627\u0644\u062b\u0646\u064a\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062b\u0646\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062b\u0646\u06cc\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Thenia"
+    ],
+    "name:cat_x_preferred":[
+        "Th\u00e9nia"
     ],
     "name:ceb_x_preferred":[
         "Thenia"
@@ -43,16 +55,37 @@
     "name:fra_x_preferred":[
         "Thenia"
     ],
+    "name:fra_x_variant":[
+        "Th\u00e9nia"
+    ],
+    "name:hau_x_preferred":[
+        "Th\u00e9nia"
+    ],
+    "name:hye_x_preferred":[
+        "\u0539\u0565\u0576\u056b\u0561"
+    ],
+    "name:ind_x_preferred":[
+        "Thenia"
+    ],
     "name:ita_x_preferred":[
         "Th\u00e9nia"
     ],
+    "name:jpn_x_preferred":[
+        "\u30c6\u30cb\u30a2"
+    ],
     "name:kab_x_preferred":[
         "Tala \u03b5ica"
+    ],
+    "name:msa_x_preferred":[
+        "Thenia"
     ],
     "name:nan_x_preferred":[
         "Th\u00e9nia"
     ],
     "name:nld_x_preferred":[
+        "Th\u00e9nia"
+    ],
+    "name:pol_x_preferred":[
         "Th\u00e9nia"
     ],
     "name:por_x_preferred":[
@@ -65,6 +98,9 @@
         "Th\u00e9nia"
     ],
     "name:spa_x_preferred":[
+        "Thenia"
+    ],
+    "name:swa_x_preferred":[
         "Thenia"
     ],
     "name:swe_x_preferred":[
@@ -119,7 +155,7 @@
         }
     ],
     "wof:id":1125959019,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875558,
     "wof:name":"Thenia",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/112/598/830/5/1125988305.geojson
+++ b/data/112/598/830/5/1125988305.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u064a\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u064a\u0627\u0646"
+    ],
     "name:ceb_x_preferred":[
         "Berriane"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30ea\u30a2\u30f3"
+    ],
+    "name:kab_x_preferred":[
+        "Berreyyan"
     ],
     "name:msa_x_preferred":[
         "Berriane"
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":1125988305,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1690875563,
     "wof:name":"Berriane",
     "wof:parent_id":85670749,
     "wof:placetype":"locality",

--- a/data/112/598/981/9/1125989819.geojson
+++ b/data/112/598/981/9/1125989819.geojson
@@ -25,10 +25,16 @@
     "name:ara_x_preferred":[
         "\u0622\u0631\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0631\u064a\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u0622\u0631\u06cc\u0633"
     ],
     "name:bre_x_preferred":[
+        "Arris"
+    ],
+    "name:cat_x_preferred":[
         "Arris"
     ],
     "name:ceb_x_preferred":[
@@ -58,6 +64,9 @@
     "name:nld_x_preferred":[
         "Arris"
     ],
+    "name:pol_x_preferred":[
+        "Arris"
+    ],
     "name:por_x_preferred":[
         "Arris"
     ],
@@ -71,6 +80,12 @@
         "Arris"
     ],
     "name:vie_x_preferred":[
+        "Arris"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u91cc\u65af"
+    ],
+    "name:zul_x_preferred":[
         "Arris"
     ],
     "qs_pg:aaroncc":"DZ",
@@ -110,7 +125,7 @@
         }
     ],
     "wof:id":1125989819,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1690875563,
     "wof:name":"Arris",
     "wof:parent_id":85670851,
     "wof:placetype":"locality",

--- a/data/112/601/204/5/1126012045.geojson
+++ b/data/112/601/204/5/1126012045.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u062d\u0627\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u062d\u0627\u0644"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u062d\u0627\u0644"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Berrahal"
+    ],
+    "name:kab_x_preferred":[
+        "Berre\u1e25\u1e25al"
     ],
     "name:msa_x_preferred":[
         "Berrahal"
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":1126012045,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1690875563,
     "wof:name":"Berrahal",
     "wof:parent_id":85670713,
     "wof:placetype":"locality",

--- a/data/112/601/205/1/1126012051.geojson
+++ b/data/112/601/205/1/1126012051.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_variant":[
         "\u0623\u0628\u0648 \u0627\u0644\u062d\u0633\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0628\u0648 \u0627\u0644\u062d\u0633\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0628\u0648\u0627\u0644\u062d\u0633\u0646"
     ],
@@ -41,6 +44,9 @@
         "\u0627\u0628\u0648 \u0627\u0644 \u062d\u0633\u0646"
     ],
     "name:fra_x_preferred":[
+        "Abou El Hassan"
+    ],
+    "name:glg_x_preferred":[
         "Abou El Hassan"
     ],
     "name:ita_x_preferred":[
@@ -64,6 +70,9 @@
     "name:ron_x_preferred":[
         "Abou El Hassan"
     ],
+    "name:spa_x_preferred":[
+        "Abou El Hassan"
+    ],
     "name:swe_x_preferred":[
         "Abou el Hassan"
     ],
@@ -78,6 +87,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u5e03\u54c8\u6851"
+    ],
+    "name:zul_x_preferred":[
+        "Abou El Hassen"
     ],
     "qs_pg:aaroncc":"DZ",
     "qs_pg:gn_country":"DZ",
@@ -116,7 +128,7 @@
         }
     ],
     "wof:id":1126012051,
-    "wof:lastmodified":1566583522,
+    "wof:lastmodified":1690875563,
     "wof:name":"Abou el Hassan",
     "wof:parent_id":85670781,
     "wof:placetype":"locality",

--- a/data/114/190/618/1/1141906181.geojson
+++ b/data/114/190/618/1/1141906181.geojson
@@ -21,8 +21,14 @@
     "name:ara_x_preferred":[
         "\u062c\u064a\u062c\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u064a\u062c\u0644"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u06cc\u062c\u0644"
+    ],
+    "name:aze_x_preferred":[
+        "Cic\u0259l"
     ],
     "name:ben_x_preferred":[
         "\u099c\u09bf\u099c\u09c7\u09b2"
@@ -33,6 +39,9 @@
     "name:ceb_x_preferred":[
         "Jijel"
     ],
+    "name:ces_x_preferred":[
+        "D\u017eid\u017eel"
+    ],
     "name:dan_x_preferred":[
         "Jijel"
     ],
@@ -41,6 +50,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b6\u03af\u03c4\u03b6\u03b5\u03bb"
+    ],
+    "name:ell_x_variant":[
+        "\u03a4\u03b6\u03b9\u03c4\u03b6\u03ad\u03bb"
     ],
     "name:eng_x_preferred":[
         "Jijel"
@@ -73,6 +85,9 @@
         "\u091c\u093f\u091c\u0947\u0932"
     ],
     "name:hun_x_preferred":[
+        "Jijel"
+    ],
+    "name:ina_x_preferred":[
         "Jijel"
     ],
     "name:ind_x_preferred":[
@@ -139,6 +154,12 @@
         "\u0da2\u0dd2\u0da2\u0dd9\u0dbd\u0dca"
     ],
     "name:spa_x_preferred":[
+        "Jijel"
+    ],
+    "name:srp_x_preferred":[
+        "\u040f\u0438\u045f\u0435\u043b"
+    ],
+    "name:swa_x_preferred":[
         "Jijel"
     ],
     "name:swe_x_preferred":[
@@ -291,7 +312,7 @@
         }
     ],
     "wof:id":1141906181,
-    "wof:lastmodified":1636501725,
+    "wof:lastmodified":1690875567,
     "wof:name":"Jijel",
     "wof:parent_id":85670723,
     "wof:placetype":"locality",

--- a/data/114/190/618/7/1141906187.geojson
+++ b/data/114/190/618/7/1141906187.geojson
@@ -21,13 +21,22 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0632\u064a \u0648\u0632\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0632\u0649 \u0648\u0632\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0632\u06cc \u0648\u0632\u0648"
+    ],
+    "name:aze_x_preferred":[
+        "Tizi-Uzu"
     ],
     "name:ben_x_preferred":[
         "\u09a4\u09bf\u099c\u09bf \u0994\u099c\u09c1"
     ],
     "name:bre_x_preferred":[
+        "Tizi Ouzou"
+    ],
+    "name:cat_x_preferred":[
         "Tizi Ouzou"
     ],
     "name:ceb_x_preferred":[
@@ -78,6 +87,9 @@
     "name:hun_x_preferred":[
         "Tizi-Ouzou"
     ],
+    "name:hye_x_preferred":[
+        "\u054f\u056b\u0566\u056b \u0548\u0582\u0566\u0578\u0582"
+    ],
     "name:ind_x_preferred":[
         "Tizi Ouzou"
     ],
@@ -123,6 +135,9 @@
     "name:nob_x_preferred":[
         "Tizi Ouzou"
     ],
+    "name:oci_x_preferred":[
+        "Tizi Ozo"
+    ],
     "name:pnb_x_preferred":[
         "\u062a\u06cc\u0632\u06cc \u0648\u0632\u0648"
     ],
@@ -138,10 +153,16 @@
     "name:rus_x_preferred":[
         "\u0422\u0438\u0437\u0438-\u0423\u0437\u0443"
     ],
+    "name:shi_x_preferred":[
+        "Tizi Uzzu"
+    ],
     "name:sin_x_preferred":[
         "\u0da7\u0dca\u0dc3\u0dd2 \u0d96\u0dc3\u0dd4"
     ],
     "name:spa_x_preferred":[
+        "Tizi Ouzou"
+    ],
+    "name:swa_x_preferred":[
         "Tizi Ouzou"
     ],
     "name:swe_x_preferred":[
@@ -176,6 +197,9 @@
     ],
     "name:zho_x_preferred":[
         "\u63d0\u6d4e\u4e4c\u7956"
+    ],
+    "name:zul_x_preferred":[
+        "Tizi Ouzou"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -294,7 +318,7 @@
         }
     ],
     "wof:id":1141906187,
-    "wof:lastmodified":1636501725,
+    "wof:lastmodified":1690875567,
     "wof:name":"Tizi-Ouzou",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/114/190/618/9/1141906189.geojson
+++ b/data/114/190/618/9/1141906189.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"4.62999646641,36.0590040083,4.62999646641,36.0590040083",
+    "geom:bbox":"4.629996,36.059004,4.629996,36.059004",
     "geom:latitude":36.059004,
     "geom:longitude":4.629996,
     "iso:country":"DZ",
@@ -21,8 +21,17 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c"
+    ],
+    "name:ast_x_preferred":[
+        "Bordj Bou Arr\u00e9ridj"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u062c \u0628\u0648 \u0639\u0631\u06cc\u0631\u06cc\u062c"
+    ],
+    "name:aze_x_preferred":[
+        "B\u00fcrc-B\u00fc-\u018frriric"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09a1\u099c \u09ac\u09cc \u0986\u09b0\u09c7\u0987\u099c"
@@ -39,17 +48,24 @@
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bf\u03c1\u03bd\u03c4\u03b6 \u039c\u03c0\u03bf\u03c5 \u0391\u03c1\u03b5\u03c1\u03af\u03bd\u03c4\u03b6"
     ],
+    "name:ell_x_variant":[
+        "\u039c\u03c0\u03bf\u03c1\u03c4\u03b6 \u039c\u03c0\u03bf\u03c5 \u0391\u03c1\u03b5\u03c1\u03af\u03c4\u03b6"
+    ],
     "name:eng_x_preferred":[
         "Bordj Bou Arr\u00e9ridj"
     ],
     "name:epo_x_preferred":[
         "Bor\u011d Bu Areri\u011d"
     ],
+    "name:eus_x_preferred":[
+        "Bordj Bou Arreridj"
+    ],
     "name:fas_x_preferred":[
         "\u0628\u0631\u062c \u0628\u0648 \u0639\u0631\u06cc\u0631\u06cc\u062c\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
     ],
     "name:fas_x_variant":[
-        "\u0628\u0631\u062c \u0628\u0648 \u0639\u0631\u06cc\u0631\u06cc\u062c"
+        "\u0628\u0631\u062c \u0628\u0648 \u0639\u0631\u06cc\u0631\u06cc\u062c",
+        "\u0628\u0631\u062c \u0628\u0648\u0639\u0631\u06cc\u0631\u06cc\u062c"
     ],
     "name:fin_x_preferred":[
         "Bordj Bou Arreridj"
@@ -59,6 +75,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0aac\u0acb\u0ab0\u0acd\u0aa1\u0ac7\u0a9c\u0acd \u0aac\u0acc \u0a85\u0ab0\u0ac7\u0ab0\u0abf\u0a9c"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d5\u05e8\u05d2' \u05d0\u05d1\u05d5 \u05d0\u05e8\u05d2'"
     ],
     "name:hin_x_preferred":[
         "\u092c\u094b\u0930\u094d\u091c \u092c\u094b\u0909 \u0905\u0930\u0940\u091c"
@@ -74,6 +93,9 @@
     ],
     "name:kab_x_preferred":[
         "Bur\u01e7 Bu A\u025briri\u01e7"
+    ],
+    "name:kab_x_variant":[
+        "Bur\u01e7 Bu\u025briri\u01e7"
     ],
     "name:kan_x_preferred":[
         "\u0cac\u0ccb\u0cb0\u0ccd\u0c9c\u0ccd \u0cac\u0ccc \u0c85\u0cb0\u0cc6\u0cb0\u0cbf\u0ca1\u0ccd\u0c9c\u0ccd"
@@ -123,6 +145,9 @@
     "name:spa_x_preferred":[
         "Bordj Bou Arr\u00e9ridj"
     ],
+    "name:swa_x_preferred":[
+        "Bordj Bou Arreridj"
+    ],
     "name:swe_x_preferred":[
         "Bordj Bou Arr\u00e9ridj"
     ],
@@ -143,6 +168,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0628\u0631\u062c \u0628\u0648 \u0639\u0631\u06cc\u0631\u06cc\u062c"
+    ],
+    "name:uzb_x_preferred":[
+        "Bordj Bou Arr\u00e9ridj"
     ],
     "name:vie_x_preferred":[
         "Bordj Bou Arreridj"
@@ -260,7 +288,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1499130553,
-    "wof:geomhash":"184a7f347dd047db420171103e6cc371",
+    "wof:geomhash":"0d846b6b3e5353fb48f59622ad21b94c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -270,7 +298,7 @@
         }
     ],
     "wof:id":1141906189,
-    "wof:lastmodified":1566583773,
+    "wof:lastmodified":1690875566,
     "wof:name":"Bordj Bou Arreridj",
     "wof:parent_id":85670809,
     "wof:placetype":"locality",
@@ -280,10 +308,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    4.62999646640503,
-    36.05900400826653,
-    4.62999646640503,
-    36.05900400826653
+    4.629996,
+    36.059004,
+    4.629996,
+    36.059004
 ],
-  "geometry": {"coordinates":[4.62999646640503,36.05900400826653],"type":"Point"}
+  "geometry": {"coordinates":[4.629996,36.059004],"type":"Point"}
 }

--- a/data/114/190/619/1/1141906191.geojson
+++ b/data/114/190/619/1/1141906191.geojson
@@ -21,8 +21,14 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u0633\u064a\u0644\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u0633\u064a\u0644\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0645\u0633\u06cc\u0644\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Msila"
     ],
     "name:ben_x_preferred":[
         "\u098f\u09ae \u099c\u09bf\u09b2\u09be"
@@ -36,8 +42,14 @@
     "name:dan_x_preferred":[
         "M'Sila"
     ],
+    "name:deu_x_preferred":[
+        "M'Sila"
+    ],
     "name:ell_x_preferred":[
         "\u0395\u03bc\u03c3\u03af\u03bb\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u039c'\u03c3\u03b9\u03bb\u03ac"
     ],
     "name:eng_x_preferred":[
         "M'Sila"
@@ -80,6 +92,9 @@
     ],
     "name:kab_x_preferred":[
         "Msila"
+    ],
+    "name:kab_x_variant":[
+        "Tamsilt"
     ],
     "name:kan_x_preferred":[
         "\u0c8e\u0c82\u0cb8\u0cbf\u0cb2\u0cbe"
@@ -133,6 +148,9 @@
         "M'Sila"
     ],
     "name:spa_x_preferred":[
+        "M'Sila"
+    ],
+    "name:swa_x_preferred":[
         "M'Sila"
     ],
     "name:swe_x_preferred":[
@@ -285,7 +303,7 @@
         }
     ],
     "wof:id":1141906191,
-    "wof:lastmodified":1636501725,
+    "wof:lastmodified":1690875566,
     "wof:name":"M'sila",
     "wof:parent_id":85670841,
     "wof:placetype":"locality",

--- a/data/114/190/821/7/1141908217.geojson
+++ b/data/114/190/821/7/1141908217.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-1.2513812677,32.0492698354,-1.2513812677,32.0492698354",
+    "geom:bbox":"-1.251381,32.04927,-1.251381,32.04927",
     "geom:latitude":32.04927,
     "geom:longitude":-1.251381,
     "iso:country":"DZ",
@@ -20,6 +20,9 @@
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a \u0648\u0646\u064a\u0641"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u0649 \u0648\u0646\u064a\u0641"
     ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc \u0648\u0646\u06cc\u0641"
@@ -51,6 +54,9 @@
     "name:nld_x_preferred":[
         "B\u00e9ni Ounif"
     ],
+    "name:pol_x_preferred":[
+        "B\u00e9ni Ounif"
+    ],
     "name:por_x_preferred":[
         "B\u00e9ni Ounif"
     ],
@@ -65,6 +71,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8c9d\u5c3c\u70cf\u5c3c\u592b"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9ni Ounif"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -173,7 +182,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1499130852,
-    "wof:geomhash":"534d6b89579fc4e9f93acc93cf16f7d0",
+    "wof:geomhash":"aeebdfb8b724e82e1d7ea6aa7d3cb558",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -183,7 +192,7 @@
         }
     ],
     "wof:id":1141908217,
-    "wof:lastmodified":1566583773,
+    "wof:lastmodified":1690875566,
     "wof:name":"Beni Ounif",
     "wof:parent_id":85670699,
     "wof:placetype":"locality",
@@ -193,10 +202,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.25138126769571,
-    32.04926983543101,
-    -1.25138126769571,
-    32.04926983543101
+    -1.251381,
+    32.04927,
+    -1.251381,
+    32.04927
 ],
-  "geometry": {"coordinates":[-1.25138126769571,32.04926983543101],"type":"Point"}
+  "geometry": {"coordinates":[-1.251381,32.04927],"type":"Point"}
 }

--- a/data/114/190/822/1/1141908221.geojson
+++ b/data/114/190/822/1/1141908221.geojson
@@ -21,14 +21,23 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0639\u0628\u0627\u062f\u0644\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u0628\u0627\u062f\u0644\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0628\u0627\u062f\u0644\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Abadla"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09ac\u09be\u09a6\u09b2\u09be"
     ],
     "name:deu_x_preferred":[
         "Abadla"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bc\u03c0\u03b1\u03bd\u03c4\u03bb\u03ac"
     ],
     "name:eng_x_preferred":[
         "Abadla"
@@ -110,6 +119,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u5df4\u5fb7\u840a"
+    ],
+    "name:zul_x_preferred":[
+        "Abadla"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -228,7 +240,7 @@
         }
     ],
     "wof:id":1141908221,
-    "wof:lastmodified":1636501727,
+    "wof:lastmodified":1690875572,
     "wof:name":"Abadla",
     "wof:parent_id":85670699,
     "wof:placetype":"locality",

--- a/data/114/190/822/3/1141908223.geojson
+++ b/data/114/190/822/3/1141908223.geojson
@@ -21,8 +21,17 @@
     "name:ara_x_preferred":[
         "\u062c\u0627\u0646\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0627\u0646\u062a"
+    ],
+    "name:ast_x_preferred":[
+        "Djanet"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u0627\u0646\u062a"
+    ],
+    "name:aze_x_preferred":[
+        "Canet"
     ],
     "name:ben_x_preferred":[
         "\u09a6\u099c\u09be\u09a8\u09c7\u09a4"
@@ -32,6 +41,9 @@
     ],
     "name:deu_x_preferred":[
         "Djanet"
+    ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03b6\u03b1\u03bd\u03ad\u03c4"
     ],
     "name:eng_x_preferred":[
         "Djanet"
@@ -56,6 +68,9 @@
     ],
     "name:hun_x_preferred":[
         "Djanet"
+    ],
+    "name:hye_x_preferred":[
+        "\u054b\u0561\u0576\u0565\u0569"
     ],
     "name:ind_x_preferred":[
         "Djanet"
@@ -237,7 +252,7 @@
         }
     ],
     "wof:id":1141908223,
-    "wof:lastmodified":1636501727,
+    "wof:lastmodified":1690875572,
     "wof:name":"Djanet",
     "wof:parent_id":85670731,
     "wof:placetype":"locality",

--- a/data/114/190/822/7/1141908227.geojson
+++ b/data/114/190/822/7/1141908227.geojson
@@ -21,8 +21,14 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0623\u0645\u0642\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0645\u0642\u0644"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0627\u0645\u0642\u0644"
+    ],
+    "name:aze_x_preferred":[
+        "\u0130n-\u018fmg\u0259l"
     ],
     "name:ben_x_preferred":[
         "\u0987\u09a8 \u0986\u09ae\u0997\u09c1\u09df\u09c7\u09b2"
@@ -54,6 +60,9 @@
     "name:ind_x_preferred":[
         "Bandar Udara In Guezzam"
     ],
+    "name:ind_x_variant":[
+        "In Amguel"
+    ],
     "name:ita_x_preferred":[
         "In Amguel"
     ],
@@ -68,6 +77,9 @@
     ],
     "name:msa_x_preferred":[
         "Lapangan Terbang In Guezzam"
+    ],
+    "name:msa_x_variant":[
+        "In Amguel"
     ],
     "name:nan_x_preferred":[
         "In Amguel"
@@ -110,6 +122,9 @@
     ],
     "name:zho_x_preferred":[
         "\u56e0\u963f\u59c6\u84cb\u52d2"
+    ],
+    "name:zul_x_preferred":[
+        "In Amguel"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -228,7 +243,7 @@
         }
     ],
     "wof:id":1141908227,
-    "wof:lastmodified":1636501727,
+    "wof:lastmodified":1690875571,
     "wof:name":"In Amguel",
     "wof:parent_id":85670735,
     "wof:placetype":"locality",

--- a/data/114/190/822/9/1141908229.geojson
+++ b/data/114/190/822/9/1141908229.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u064a\u0651\u0636"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u064a\u0651\u0636"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0628\u06cc\u0636"
     ],
@@ -33,11 +36,17 @@
     "name:deu_x_preferred":[
         "El Bayadh"
     ],
+    "name:ell_x_preferred":[
+        "\u0395\u03bb \u039c\u03c0\u03b1\u03b3\u03b9\u03ac\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "El Bayadh"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0628\u06cc\u0636"
+    ],
+    "name:fin_x_preferred":[
+        "El Bayadh"
     ],
     "name:fra_x_preferred":[
         "El Bayadh"
@@ -51,11 +60,17 @@
     "name:hun_x_preferred":[
         "El-Bayadh"
     ],
+    "name:hye_x_preferred":[
+        "\u0537\u056c \u0532\u0561\u0575\u0561\u0564"
+    ],
     "name:ind_x_preferred":[
         "El Bayadh"
     ],
     "name:ita_x_preferred":[
         "El Bayadh"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a8\u30eb\u30fb\u30d0\u30e4\u30fc\u30c9"
     ],
     "name:kab_x_preferred":[
         "Lbeyye\u1e0d"
@@ -91,6 +106,9 @@
         "\u042d\u043b\u044c-\u0411\u0430\u044f\u0434"
     ],
     "name:spa_x_preferred":[
+        "El Bayadh"
+    ],
+    "name:swa_x_preferred":[
         "El Bayadh"
     ],
     "name:swe_x_preferred":[
@@ -231,7 +249,7 @@
         }
     ],
     "wof:id":1141908229,
-    "wof:lastmodified":1636501727,
+    "wof:lastmodified":1690875571,
     "wof:name":"El Bayadh",
     "wof:parent_id":85670741,
     "wof:placetype":"locality",

--- a/data/114/190/823/1/1141908231.geojson
+++ b/data/114/190/823/1/1141908231.geojson
@@ -21,6 +21,15 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0648\u0627\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0648\u0627\u062f\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "El Oued"
+    ],
+    "name:bel_x_preferred":[
+        "\u042d\u043b\u044c-\u0423\u044d\u0434"
+    ],
     "name:ben_x_preferred":[
         "\u098f\u09b2 \u0993\u09af\u09bc\u09c7\u09a1"
     ],
@@ -44,6 +53,9 @@
     ],
     "name:epo_x_preferred":[
         "El Ued"
+    ],
+    "name:eus_x_preferred":[
+        "El Oued"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0648\u0627\u062f\u06cc\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -81,6 +93,9 @@
     "name:jpn_x_preferred":[
         "\u30a8\u30eb\uff1d\u30a6\u30a7\u30c3\u30c9"
     ],
+    "name:kab_x_preferred":[
+        "Lwad"
+    ],
     "name:kan_x_preferred":[
         "\u0c8e\u0cb2\u0ccd \u0c94\u0ca1\u0ccd"
     ],
@@ -89,6 +104,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc5d8\uc6e8\ub4dc"
+    ],
+    "name:lat_x_preferred":[
+        "Potamopolis"
     ],
     "name:lav_x_preferred":[
         "Ueda"
@@ -136,6 +154,12 @@
         "El Oued"
     ],
     "name:spa_x_preferred":[
+        "El Oued"
+    ],
+    "name:srp_x_preferred":[
+        "\u0415\u043b \u0423\u0458\u0435\u0434"
+    ],
+    "name:swa_x_preferred":[
         "El Oued"
     ],
     "name:swe_x_preferred":[
@@ -285,7 +309,7 @@
         }
     ],
     "wof:id":1141908231,
-    "wof:lastmodified":1636501726,
+    "wof:lastmodified":1690875569,
     "wof:name":"El Oued",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",

--- a/data/114/190/823/5/1141908235.geojson
+++ b/data/114/190/823/5/1141908235.geojson
@@ -21,6 +21,12 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0644\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0644\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "Chlef"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0644\u0641"
     ],
@@ -41,6 +47,9 @@
     ],
     "name:deu_x_preferred":[
         "Ech Cheliff"
+    ],
+    "name:deu_x_variant":[
+        "Fez"
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03bb\u03b5\u03c6"
@@ -63,6 +72,9 @@
     "name:fra_x_preferred":[
         "Chlef"
     ],
+    "name:gle_x_preferred":[
+        "Chlef"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0acd\u0ab2\u0ac7\u0aab"
     ],
@@ -74,6 +86,9 @@
     ],
     "name:hun_x_preferred":[
         "Chlef"
+    ],
+    "name:hye_x_preferred":[
+        "\u0547\u056c\u0565\u0586"
     ],
     "name:ind_x_preferred":[
         "Chlef"
@@ -105,6 +120,9 @@
     "name:mar_x_preferred":[
         "\u0915\u094d\u0932\u0947\u092b"
     ],
+    "name:mdf_x_preferred":[
+        "\u0428\u043b\u044d\u0444"
+    ],
     "name:msa_x_preferred":[
         "Chlef"
     ],
@@ -116,6 +134,9 @@
     ],
     "name:nob_x_preferred":[
         "Chlef"
+    ],
+    "name:nob_x_variant":[
+        "Ech Cheliff"
     ],
     "name:pnb_x_preferred":[
         "\u0634\u0644\u0641"
@@ -132,10 +153,19 @@
     "name:rus_x_preferred":[
         "\u0428\u043b\u0435\u0444"
     ],
+    "name:rus_x_variant":[
+        "\u042d\u0448-\u0428\u0435\u043b\u0438\u0444\u0444"
+    ],
     "name:sin_x_preferred":[
         "\u0da0\u0dd9\u0dbd\u0dca\u0dc6\u0dca"
     ],
     "name:spa_x_preferred":[
+        "Chlef"
+    ],
+    "name:spa_x_variant":[
+        "F\u00e8s"
+    ],
+    "name:swa_x_preferred":[
         "Chlef"
     ],
     "name:swe_x_preferred":[
@@ -162,6 +192,9 @@
     "name:urd_x_preferred":[
         "\u0634\u0644\u0641"
     ],
+    "name:vec_x_preferred":[
+        "Chlef"
+    ],
     "name:vie_x_preferred":[
         "Chlef"
     ],
@@ -171,8 +204,14 @@
     "name:wln_x_preferred":[
         "Chlef"
     ],
+    "name:yue_x_preferred":[
+        "\u8b1d\u5229\u592b"
+    ],
     "name:zho_x_preferred":[
         "\u8c22\u5229\u592b"
+    ],
+    "name:zul_x_preferred":[
+        "Chlef"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -291,7 +330,7 @@
         }
     ],
     "wof:id":1141908235,
-    "wof:lastmodified":1636501726,
+    "wof:lastmodified":1690875570,
     "wof:name":"Chlef",
     "wof:parent_id":85670781,
     "wof:placetype":"locality",

--- a/data/114/190/823/9/1141908239.geojson
+++ b/data/114/190/823/9/1141908239.geojson
@@ -21,8 +21,17 @@
     "name:ara_x_preferred":[
         "\u0645\u0639\u0633\u0643\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0639\u0633\u0643\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Mascara"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0639\u0633\u06a9\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "M\u0259sk\u0259r"
     ],
     "name:bel_x_preferred":[
         "\u041c\u0430\u0441\u043a\u0430\u0440\u0430"
@@ -69,17 +78,26 @@
     "name:fra_x_preferred":[
         "Mascara"
     ],
+    "name:gle_x_preferred":[
+        "Mascara"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0ab8\u0acd\u0a95\u0ab0\u0abe"
     ],
     "name:heb_x_preferred":[
         "\u05de\u05d0\u05e1\u05e8\u05d5"
     ],
+    "name:heb_x_variant":[
+        "\u05de\u05e1\u05e7\u05e8\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u092e\u0938\u094d\u0915\u093e\u0930\u093e"
     ],
     "name:hun_x_preferred":[
         "Mascara"
+    ],
+    "name:hun_x_variant":[
+        "M\u00e1szkara"
     ],
     "name:hye_x_preferred":[
         "\u0544\u0561\u057d\u056f\u0561\u0580\u0561"
@@ -123,6 +141,9 @@
     "name:nob_x_preferred":[
         "Mascara"
     ],
+    "name:oss_x_preferred":[
+        "\u041c\u0430\u0441\u043a\u0430\u0440\u00e6"
+    ],
     "name:pol_x_preferred":[
         "Muaskar"
     ],
@@ -140,6 +161,9 @@
     ],
     "name:spa_x_preferred":[
         "Muaskar"
+    ],
+    "name:swa_x_preferred":[
+        "Mascara"
     ],
     "name:swe_x_preferred":[
         "Muaskar"
@@ -167,6 +191,9 @@
     ],
     "name:urd_x_variant":[
         "\u0645\u0639\u0633\u06a9\u0631"
+    ],
+    "name:vec_x_preferred":[
+        "Mascara"
     ],
     "name:vie_x_preferred":[
         "Mascara"
@@ -294,7 +321,7 @@
         }
     ],
     "wof:id":1141908239,
-    "wof:lastmodified":1636501726,
+    "wof:lastmodified":1690875569,
     "wof:name":"Mascara",
     "wof:parent_id":85670785,
     "wof:placetype":"locality",

--- a/data/114/190/824/3/1141908243.geojson
+++ b/data/114/190/824/3/1141908243.geojson
@@ -24,14 +24,29 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u0644\u064a\u062f\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u0644\u064a\u062f\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Blida"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0628\u0644\u06cc\u062f\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Blida"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u043b\u0456\u0434\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u0411\u043b\u0456\u0434\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09cd\u09b2\u09bf\u09a1\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09ac\u09cd\u09b2\u09bf\u09a6\u09be"
     ],
     "name:bre_x_preferred":[
         "El Bouleida"
@@ -57,6 +72,9 @@
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bb\u03af\u03bd\u03c4\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u039c\u03c0\u03bb\u03b9\u03bd\u03c4\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Blida"
     ],
@@ -73,6 +91,9 @@
         "Blida"
     ],
     "name:fra_x_preferred":[
+        "Blida"
+    ],
+    "name:frr_x_preferred":[
         "Blida"
     ],
     "name:guj_x_preferred":[
@@ -168,6 +189,9 @@
     "name:spa_x_preferred":[
         "Blida"
     ],
+    "name:swa_x_preferred":[
+        "Blida"
+    ],
     "name:swe_x_preferred":[
         "Blida"
     ],
@@ -203,6 +227,9 @@
     ],
     "name:zho_x_preferred":[
         "\u535c\u5229\u8fbe"
+    ],
+    "name:zul_x_preferred":[
+        "Blida"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -321,7 +348,7 @@
         }
     ],
     "wof:id":1141908243,
-    "wof:lastmodified":1636501727,
+    "wof:lastmodified":1690875570,
     "wof:name":"Blida",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/114/190/824/5/1141908245.geojson
+++ b/data/114/190/824/5/1141908245.geojson
@@ -21,8 +21,20 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u0648\u064a\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u0648\u064a\u0631\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Bou\u00efra"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u06cc\u0631\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Buira"
+    ],
+    "name:cat_x_preferred":[
+        "Bouira"
     ],
     "name:ceb_x_preferred":[
         "Bou\u00efra"
@@ -30,11 +42,17 @@
     "name:deu_x_preferred":[
         "Bouira"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03c5\u03af\u03c1\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Bou\u00efra"
     ],
     "name:fas_x_preferred":[
         "\u0628\u0648\u06cc\u0631\u0647"
+    ],
+    "name:fin_x_preferred":[
+        "Bouira"
     ],
     "name:fra_x_preferred":[
         "Bouira"
@@ -44,6 +62,9 @@
     ],
     "name:hun_x_preferred":[
         "Bouira"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u0578\u0582\u056b\u0580\u0561"
     ],
     "name:ita_x_preferred":[
         "Bouira"
@@ -84,11 +105,17 @@
     "name:spa_x_preferred":[
         "Bouira"
     ],
+    "name:swa_x_preferred":[
+        "Bouira"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0443\u0457\u0440\u0430"
     ],
     "name:urd_x_preferred":[
         "\u0628\u0648\u06cc\u0631\u06c1"
+    ],
+    "name:uzb_x_preferred":[
+        "Buira"
     ],
     "name:vie_x_preferred":[
         "Bouira"
@@ -98,6 +125,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e03\u7ef4\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Bou\u00efra"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -216,7 +246,7 @@
         }
     ],
     "wof:id":1141908245,
-    "wof:lastmodified":1636501727,
+    "wof:lastmodified":1690875571,
     "wof:name":"Bouira",
     "wof:parent_id":85670823,
     "wof:placetype":"locality",

--- a/data/114/190/824/7/1141908247.geojson
+++ b/data/114/190/824/7/1141908247.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"2.77000117861,36.2704075308,2.77000117861,36.2704075308",
+    "geom:bbox":"2.770001,36.270408,2.770001,36.270408",
     "geom:latitude":36.270408,
     "geom:longitude":2.770001,
     "iso:country":"DZ",
@@ -21,8 +21,17 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u062f\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u062f\u064a\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "M\u00e9d\u00e9a"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0645\u062f\u06cc\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "M\u0259diya"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09c7\u09a6\u09bf\u09af\u09bc\u09be"
@@ -84,6 +93,9 @@
     "name:kab_x_preferred":[
         "Lemdiyyet"
     ],
+    "name:kab_x_variant":[
+        "Lemdeyya"
+    ],
     "name:kan_x_preferred":[
         "\u0cae\u0cc6\u0ca1\u0cbf\u0caf\u0cbe"
     ],
@@ -127,6 +139,9 @@
         "\u0db8\u0dd9\u0daf\u0dd2\u0dba\u0dcf"
     ],
     "name:spa_x_preferred":[
+        "M\u00e9d\u00e9a"
+    ],
+    "name:swa_x_preferred":[
         "M\u00e9d\u00e9a"
     ],
     "name:swe_x_preferred":[
@@ -266,7 +281,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1499130859,
-    "wof:geomhash":"33fb969a7116a1ec61b3d9f8adbbeba5",
+    "wof:geomhash":"55e8f1f91e71cefc80a557ed2b7896ca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -276,7 +291,7 @@
         }
     ],
     "wof:id":1141908247,
-    "wof:lastmodified":1566583776,
+    "wof:lastmodified":1690875570,
     "wof:name":"Medea",
     "wof:parent_id":85670837,
     "wof:placetype":"locality",
@@ -286,10 +301,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    2.77000117860945,
-    36.27040753076056,
-    2.77000117860945,
-    36.27040753076056
+    2.770001,
+    36.270408,
+    2.770001,
+    36.270408
 ],
-  "geometry": {"coordinates":[2.77000117860945,36.27040753076056],"type":"Point"}
+  "geometry": {"coordinates":[2.770001,36.270408],"type":"Point"}
 }

--- a/data/114/190/824/9/1141908249.geojson
+++ b/data/114/190/824/9/1141908249.geojson
@@ -21,10 +21,19 @@
     "name:ara_x_preferred":[
         "\u0633\u0648\u0642 \u0623\u0647\u0631\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0648\u0642 \u0627\u0647\u0631\u0627\u0633"
+    ],
+    "name:aze_x_preferred":[
+        "Suk-\u018fhras"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cb\u0995\u09be \u09b9\u09be\u09b8"
     ],
     "name:bre_x_preferred":[
+        "Souk Ahras"
+    ],
+    "name:cat_x_preferred":[
         "Souk Ahras"
     ],
     "name:ceb_x_preferred":[
@@ -168,6 +177,9 @@
     "name:ukr_x_preferred":[
         "\u0421\u0443\u043a-\u0410\u0445\u0440\u0430\u0441"
     ],
+    "name:ukr_x_variant":[
+        "\u0421\u0443\u043a-\u0410\u0433\u0440\u0430\u0441"
+    ],
     "name:urd_x_preferred":[
         "\u0633\u0648\u0642 \u0627\u06c1\u0631\u0627\u0633"
     ],
@@ -297,7 +309,7 @@
         }
     ],
     "wof:id":1141908249,
-    "wof:lastmodified":1636501726,
+    "wof:lastmodified":1690875570,
     "wof:name":"Souk Ahras",
     "wof:parent_id":85670875,
     "wof:placetype":"locality",

--- a/data/114/190/825/1/1141908251.geojson
+++ b/data/114/190/825/1/1141908251.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"8.12001053735,35.4104341828,8.12001053735,35.4104341828",
+    "geom:bbox":"8.120011,35.410434,8.120011,35.410434",
     "geom:latitude":35.410434,
     "geom:longitude":8.120011,
     "iso:country":"DZ",
@@ -20,6 +20,15 @@
     "mz:min_zoom":12.0,
     "name:ara_x_preferred":[
         "\u062a\u0628\u0633\u0629"
+    ],
+    "name:arq_x_preferred":[
+        "\u062a\u0628\u0633\u0629 \u062a\u064a\u0641\u064a\u0633\u062a"
+    ],
+    "name:arz_x_preferred":[
+        "\u062a\u0628\u0633\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "T\u00e9bessa"
     ],
     "name:azb_x_preferred":[
         "\u062a\u0628\u0633\u0647"
@@ -36,6 +45,9 @@
     "name:ceb_x_preferred":[
         "T\u00e9bessa"
     ],
+    "name:ces_x_preferred":[
+        "Tebessa"
+    ],
     "name:dan_x_preferred":[
         "Tebessa"
     ],
@@ -44,6 +56,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b5\u03bc\u03c0\u03ad\u03c3\u03c3\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u03a4\u03b5\u03bc\u03c0\u03ad\u03c3\u03b1"
     ],
     "name:eng_x_preferred":[
         "T\u00e9bessa"
@@ -90,6 +105,9 @@
     "name:jpn_x_preferred":[
         "\u30c6\u30d9\u30c3\u30b5"
     ],
+    "name:kab_x_preferred":[
+        "Tbessa"
+    ],
     "name:kan_x_preferred":[
         "\u0ca4\u0cc6\u0cac\u0cc6\u0cb8\u0ccd\u0cb8"
     ],
@@ -98,6 +116,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud14c\ubca0\uc0ac"
+    ],
+    "name:lat_x_preferred":[
+        "Theveste"
     ],
     "name:lav_x_preferred":[
         "Tebesa"
@@ -141,6 +162,9 @@
     "name:spa_x_preferred":[
         "T\u00e9bessa"
     ],
+    "name:swa_x_preferred":[
+        "T\u00e9bessa"
+    ],
     "name:swe_x_preferred":[
         "T\u00e9bessa"
     ],
@@ -170,6 +194,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6cf0\u8d1d\u8428"
+    ],
+    "name:zul_x_preferred":[
+        "T\u00e9bessa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -278,7 +305,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1499130859,
-    "wof:geomhash":"4df20829799013e0ec73f4845e562b35",
+    "wof:geomhash":"2c826c12b5296d85578017b6daa912dc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -288,7 +315,7 @@
         }
     ],
     "wof:id":1141908251,
-    "wof:lastmodified":1566583776,
+    "wof:lastmodified":1690875571,
     "wof:name":"Tebessa",
     "wof:parent_id":85670879,
     "wof:placetype":"locality",
@@ -298,10 +325,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    8.1200105373548,
-    35.41043418277525,
-    8.1200105373548,
-    35.41043418277525
+    8.120011,
+    35.410434,
+    8.120011,
+    35.410434
 ],
-  "geometry": {"coordinates":[8.1200105373548,35.41043418277525],"type":"Point"}
+  "geometry": {"coordinates":[8.120011,35.410434],"type":"Point"}
 }

--- a/data/114/190/912/1/1141909121.geojson
+++ b/data/114/190/912/1/1141909121.geojson
@@ -21,8 +21,17 @@
     "name:ara_x_preferred":[
         "\u0623\u062f\u0631\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u062f\u0631\u0627\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Adrar"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u0631\u0627\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fdrar"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09a6\u09cd\u09b0\u09be\u09b0"
@@ -38,6 +47,9 @@
     ],
     "name:deu_x_preferred":[
         "Adrar"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bd\u03c4\u03c1\u03ac\u03c1"
     ],
     "name:eng_x_preferred":[
         "Adrar"
@@ -81,6 +93,9 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30c9\u30e9\u30fc\u30eb"
     ],
+    "name:kab_x_preferred":[
+        "Adrar"
+    ],
     "name:kor_x_preferred":[
         "\uc544\ub4dc\ub77c\ub974"
     ],
@@ -114,11 +129,17 @@
     "name:spa_x_preferred":[
         "Adrar"
     ],
+    "name:swa_x_preferred":[
+        "Adrar"
+    ],
     "name:swe_x_preferred":[
         "Adrar"
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e32\u0e14\u0e23\u0e32\u0e23\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e14\u0e23\u0e2d\u0e23"
     ],
     "name:tur_x_preferred":[
         "Adrar"
@@ -140,6 +161,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u5fb7\u62c9\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "Adrar"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -258,7 +282,7 @@
         }
     ],
     "wof:id":1141909121,
-    "wof:lastmodified":1636501725,
+    "wof:lastmodified":1690875568,
     "wof:name":"Adrar",
     "wof:parent_id":85670677,
     "wof:placetype":"locality",

--- a/data/114/190/912/3/1141909123.geojson
+++ b/data/114/190/912/3/1141909123.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-2.23000370422,31.611105366,-2.23000370422,31.611105366",
+    "geom:bbox":"-2.230004,31.611105,-2.230004,31.611105",
     "geom:latitude":31.611105,
     "geom:longitude":-2.230004,
     "iso:country":"DZ",
@@ -21,8 +21,20 @@
     "name:ara_x_preferred":[
         "\u0628\u0634\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0634\u0627\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "B\u00e9char"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0634\u0627\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "B\u0259\u015far"
+    ],
+    "name:bel_x_preferred":[
+        "\u0411\u0435\u0448\u0430\u0440"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u0995\u09b9\u09be\u09b0"
@@ -123,6 +135,9 @@
     "name:por_x_preferred":[
         "B\u00e9char"
     ],
+    "name:pus_x_preferred":[
+        "\u0628\u0634\u0627\u0631"
+    ],
     "name:ron_x_preferred":[
         "B\u00e9char"
     ],
@@ -136,6 +151,9 @@
         "B\u00e9char"
     ],
     "name:spa_x_preferred":[
+        "B\u00e9char"
+    ],
+    "name:swa_x_preferred":[
         "B\u00e9char"
     ],
     "name:swe_x_preferred":[
@@ -170,6 +188,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8d1d\u6c99\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9char"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -278,7 +299,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1499131029,
-    "wof:geomhash":"025e0de5c90252015d714624f35813c2",
+    "wof:geomhash":"f8166d1ef5f78549d18e5dfd214cb582",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -288,7 +309,7 @@
         }
     ],
     "wof:id":1141909123,
-    "wof:lastmodified":1566583774,
+    "wof:lastmodified":1690875568,
     "wof:name":"Bechar",
     "wof:parent_id":85670699,
     "wof:placetype":"locality",
@@ -298,10 +319,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.23000370422301,
-    31.61110536602837,
-    -2.23000370422301,
-    31.61110536602837
+    -2.230004,
+    31.611105,
+    -2.230004,
+    31.611105
 ],
-  "geometry": {"coordinates":[-2.23000370422301,31.61110536602837],"type":"Point"}
+  "geometry": {"coordinates":[-2.230004,31.611105],"type":"Point"}
 }

--- a/data/114/190/912/5/1141909125.geojson
+++ b/data/114/190/912/5/1141909125.geojson
@@ -21,11 +21,20 @@
     "name:ara_x_preferred":[
         "\u062a\u0646\u062f\u0648\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0646\u062f\u0648\u0641"
+    ],
     "name:ast_x_preferred":[
         "Tinduf"
     ],
+    "name:ast_x_variant":[
+        "Tindouf"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09bf\u09a8\u09cd\u09a6\u09cb\u0989\u09ab"
+    ],
+    "name:ben_x_variant":[
+        "\u099f\u09bf\u09a8\u09a1\u09be\u0989\u09ab"
     ],
     "name:cat_x_preferred":[
         "Tindouf"
@@ -77,6 +86,9 @@
     ],
     "name:hun_x_preferred":[
         "Tindouf"
+    ],
+    "name:hye_x_preferred":[
+        "\u0539\u056b\u0576\u0564\u0578\u0582\u0586"
     ],
     "name:ind_x_preferred":[
         "Tindouf"
@@ -134,6 +146,9 @@
     ],
     "name:swe_x_preferred":[
         "Tindouf"
+    ],
+    "name:tur_x_preferred":[
+        "Tinduf"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0456\u043d\u0434\u0443\u0444"
@@ -267,7 +282,7 @@
         }
     ],
     "wof:id":1141909125,
-    "wof:lastmodified":1636501725,
+    "wof:lastmodified":1690875568,
     "wof:name":"Tindouf",
     "wof:parent_id":85670709,
     "wof:placetype":"locality",

--- a/data/114/190/912/7/1141909127.geojson
+++ b/data/114/190/912/7/1141909127.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0622\u0631\u0627\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0631\u0627\u0643"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0631\u06a9"
     ],
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":1141909127,
-    "wof:lastmodified":1636501725,
+    "wof:lastmodified":1690875567,
     "wof:name":"Arak",
     "wof:parent_id":85670735,
     "wof:placetype":"locality",

--- a/data/114/190/912/9/1141909129.geojson
+++ b/data/114/190/912/9/1141909129.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"2.88332759463,30.5666213165,2.88332759463,30.5666213165",
+    "geom:bbox":"2.883328,30.566621,2.883328,30.566621",
     "geom:latitude":30.566621,
     "geom:longitude":2.883328,
     "iso:country":"DZ",
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u0646\u064a\u0639\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u0646\u064a\u0639\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0646\u06cc\u0639\u0647"
     ],
@@ -33,11 +36,23 @@
     "name:deu_x_preferred":[
         "El Golea"
     ],
+    "name:deu_x_variant":[
+        "El Meniaa"
+    ],
+    "name:ell_x_preferred":[
+        "\u0395\u03bb \u039c\u03b5\u03bd\u03b9\u03ac"
+    ],
     "name:eng_x_preferred":[
         "El Gol\u00e9a"
     ],
+    "name:eng_x_variant":[
+        "El Menia"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0646\u06cc\u0639\u0647"
+    ],
+    "name:fin_x_preferred":[
+        "El Meniaa"
     ],
     "name:fra_x_preferred":[
         "El Menia"
@@ -50,6 +65,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a8\u30eb\u30fb\u30e1\u30cb\u30a2"
+    ],
+    "name:kab_x_preferred":[
+        "Lemni\u025ba"
     ],
     "name:lit_x_preferred":[
         "Gol\u0117ja"
@@ -195,7 +213,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1499131030,
-    "wof:geomhash":"ffa1c21b736b2d9fd69e888b03268670",
+    "wof:geomhash":"ecdfa5faffbe05f8743dc13d556c1d5a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +223,7 @@
         }
     ],
     "wof:id":1141909129,
-    "wof:lastmodified":1566583774,
+    "wof:lastmodified":1690875567,
     "wof:name":"El Golea",
     "wof:parent_id":85670749,
     "wof:placetype":"locality",
@@ -217,10 +235,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    2.8833275946256,
-    30.56662131654497,
-    2.8833275946256,
-    30.56662131654497
+    2.883328,
+    30.566621,
+    2.883328,
+    30.566621
 ],
-  "geometry": {"coordinates":[2.8833275946256,30.56662131654497],"type":"Point"}
+  "geometry": {"coordinates":[2.883328,30.566621],"type":"Point"}
 }

--- a/data/114/190/913/1/1141909131.geojson
+++ b/data/114/190/913/1/1141909131.geojson
@@ -21,11 +21,23 @@
     "name:ara_x_preferred":[
         "\u0628\u0633\u0643\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0633\u0643\u0631\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Biskra"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0633\u06a9\u0631\u0647"
     ],
+    "name:aze_x_preferred":[
+        "Biskra"
+    ],
     "name:bak_x_preferred":[
         "\u0411\u0438\u0441\u043a\u0440\u0430"
+    ],
+    "name:bel_x_preferred":[
+        "\u0411\u0456\u0441\u043a\u0440\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09bf\u09b8\u0995\u09cd\u09b0\u09be"
@@ -60,6 +72,9 @@
     "name:epo_x_preferred":[
         "Biskra"
     ],
+    "name:est_x_preferred":[
+        "Biskra"
+    ],
     "name:eus_x_preferred":[
         "Biskra"
     ],
@@ -73,6 +88,12 @@
         "Biskra"
     ],
     "name:fra_x_preferred":[
+        "Biskra"
+    ],
+    "name:frr_x_preferred":[
+        "Biskra"
+    ],
+    "name:gle_x_preferred":[
         "Biskra"
     ],
     "name:guj_x_preferred":[
@@ -89,6 +110,9 @@
     ],
     "name:hun_x_preferred":[
         "Biskra"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u056b\u057d\u056f\u0580\u0561"
     ],
     "name:ind_x_preferred":[
         "Biskra"
@@ -110,6 +134,9 @@
     ],
     "name:kor_x_preferred":[
         "\ube44\uc2a4\ud06c\ub77c"
+    ],
+    "name:lat_x_preferred":[
+        "Vescera"
     ],
     "name:lav_x_preferred":[
         "Biskra"
@@ -153,6 +180,9 @@
     "name:spa_x_preferred":[
         "Biskra"
     ],
+    "name:swa_x_preferred":[
+        "Biskra"
+    ],
     "name:swe_x_preferred":[
         "Biskra"
     ],
@@ -174,6 +204,9 @@
     "name:urd_x_preferred":[
         "\u0628\u06cc\u0633\u06a9\u0631\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Biskra"
+    ],
     "name:vie_x_preferred":[
         "Biskra"
     ],
@@ -182,6 +215,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6bd4\u65af\u514b\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Biskra"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -300,7 +336,7 @@
         }
     ],
     "wof:id":1141909131,
-    "wof:lastmodified":1636501726,
+    "wof:lastmodified":1690875568,
     "wof:name":"Biskra",
     "wof:parent_id":85670827,
     "wof:placetype":"locality",

--- a/data/114/190/913/3/1141909133.geojson
+++ b/data/114/190/913/3/1141909133.geojson
@@ -21,11 +21,23 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062c\u0644\u0641\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062c\u0644\u0641\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Djelfa"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u062c\u0641\u0644\u0647"
     ],
+    "name:aze_x_preferred":[
+        "Celfa"
+    ],
     "name:ben_x_preferred":[
         "\u099c\u09c7\u09ab\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u099c\u09c7\u09b2\u09ab\u09be"
     ],
     "name:bul_x_preferred":[
         "\u0414\u0436\u0435\u043b\u0444\u0430"
@@ -36,6 +48,9 @@
     "name:ceb_x_preferred":[
         "Djelfa"
     ],
+    "name:ces_x_preferred":[
+        "D\u017eelfa"
+    ],
     "name:dan_x_preferred":[
         "Djelfa"
     ],
@@ -44,6 +59,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b6\u03ad\u03bb\u03c6\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u03a4\u03b6\u03b5\u03bb\u03c6\u03ac"
     ],
     "name:eng_x_preferred":[
         "Djelfa"
@@ -66,6 +84,12 @@
     "name:fra_x_preferred":[
         "Djelfa"
     ],
+    "name:frr_x_preferred":[
+        "Djelfa"
+    ],
+    "name:gle_x_preferred":[
+        "Djelfa"
+    ],
     "name:guj_x_preferred":[
         "\u0a9c\u0ac7\u0ab2\u0acd\u0aab\u0abe"
     ],
@@ -78,6 +102,9 @@
     "name:hun_x_preferred":[
         "Djelfa"
     ],
+    "name:hye_x_preferred":[
+        "\u054b\u0565\u056c\u0586\u0561"
+    ],
     "name:ind_x_preferred":[
         "Djelfa"
     ],
@@ -86,6 +113,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b8\u30a7\u30eb\u30d5\u30a1"
+    ],
+    "name:kab_x_preferred":[
+        "L\u01e7elfa"
     ],
     "name:kan_x_preferred":[
         "\u0ca1\u0cbf\u0c9c\u0cc6\u0cab\u0cc6"
@@ -117,6 +147,9 @@
     "name:nob_x_preferred":[
         "Djelfa"
     ],
+    "name:oss_x_preferred":[
+        "\u0414\u0436\u0435\u043b\u044c\u0444\u00e6"
+    ],
     "name:pnb_x_preferred":[
         "\u062c\u0644\u0641\u06c1"
     ],
@@ -141,6 +174,9 @@
     "name:spa_x_preferred":[
         "Djelfa"
     ],
+    "name:swa_x_preferred":[
+        "Djelfa"
+    ],
     "name:swe_x_preferred":[
         "Djelfa"
     ],
@@ -161,6 +197,9 @@
     ],
     "name:urd_x_preferred":[
         "\u062f\u062c\u06cc\u0644\u0641\u0627"
+    ],
+    "name:vec_x_preferred":[
+        "Djelfa"
     ],
     "name:vie_x_preferred":[
         "Djelfa"
@@ -288,7 +327,7 @@
         }
     ],
     "wof:id":1141909133,
-    "wof:lastmodified":1636501726,
+    "wof:lastmodified":1690875569,
     "wof:name":"Djelfa",
     "wof:parent_id":85670833,
     "wof:placetype":"locality",

--- a/data/114/190/913/5/1141909135.geojson
+++ b/data/114/190/913/5/1141909135.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"5.39996984724,36.1800254507,5.39996984724,36.1800254507",
+    "geom:bbox":"5.39997,36.180025,5.39997,36.180025",
     "geom:latitude":36.180025,
     "geom:longitude":5.39997,
     "iso:country":"DZ",
@@ -24,14 +24,29 @@
     "name:ara_x_preferred":[
         "\u0633\u0637\u064a\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0637\u064a\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "S\u00e9tif"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0637\u06cc\u0641"
+    ],
+    "name:aze_x_preferred":[
+        "S\u0259tif"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0435\u0442\u044b\u0444"
     ],
+    "name:bel_x_variant":[
+        "\u0421\u0435\u0442\u044b\u0444"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u099f\u09bf\u09ab"
+    ],
+    "name:ben_x_variant":[
+        "\u09b8\u09c7\u09a4\u09bf\u09ab"
     ],
     "name:bre_x_preferred":[
         "Setif"
@@ -43,6 +58,9 @@
         "Sitifis"
     ],
     "name:ceb_x_preferred":[
+        "S\u00e9tif"
+    ],
+    "name:ces_x_preferred":[
         "S\u00e9tif"
     ],
     "name:dan_x_preferred":[
@@ -73,6 +91,12 @@
         "S\u00e9tif"
     ],
     "name:fra_x_preferred":[
+        "S\u00e9tif"
+    ],
+    "name:frr_x_preferred":[
+        "S\u00e9tif"
+    ],
+    "name:gle_x_preferred":[
         "S\u00e9tif"
     ],
     "name:guj_x_preferred":[
@@ -141,6 +165,12 @@
     "name:nob_x_preferred":[
         "S\u00e9tif"
     ],
+    "name:oci_x_preferred":[
+        "Setif"
+    ],
+    "name:oss_x_preferred":[
+        "\u0421\u0435\u0442\u0438\u0444"
+    ],
     "name:pnb_x_preferred":[
         "\u0633\u0637\u0641"
     ],
@@ -160,6 +190,9 @@
         "\u0dc3\u0dd9\u0da7\u0dd2\u0dc6\u0dca"
     ],
     "name:spa_x_preferred":[
+        "S\u00e9tif"
+    ],
+    "name:swa_x_preferred":[
         "S\u00e9tif"
     ],
     "name:swe_x_preferred":[
@@ -185,6 +218,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0633\u0637\u06cc\u0641"
+    ],
+    "name:vec_x_preferred":[
+        "S\u00e9tif"
     ],
     "name:vie_x_preferred":[
         "S\u00e9tif"
@@ -302,7 +338,7 @@
     },
     "wof:country":"DZ",
     "wof:created":1499131031,
-    "wof:geomhash":"1a3c6c169e48ed653ccbdc58f2128081",
+    "wof:geomhash":"47b5a2bb3b0f70959f3c7c908061e8a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +348,7 @@
         }
     ],
     "wof:id":1141909135,
-    "wof:lastmodified":1566583775,
+    "wof:lastmodified":1690875569,
     "wof:name":"Setif",
     "wof:parent_id":85670845,
     "wof:placetype":"locality",
@@ -322,10 +358,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    5.39996984723984,
-    36.18002545068208,
-    5.39996984723984,
-    36.18002545068208
+    5.39997,
+    36.180025,
+    5.39997,
+    36.180025
 ],
-  "geometry": {"coordinates":[5.39996984723984,36.18002545068208],"type":"Point"}
+  "geometry": {"coordinates":[5.39997,36.180025],"type":"Point"}
 }

--- a/data/114/190/939/7/1141909397.geojson
+++ b/data/114/190/939/7/1141909397.geojson
@@ -27,6 +27,12 @@
     "name:ara_x_variant":[
         "\u062a\u0627\u0645\u0646\u0631\u0627\u0633\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0627\u0645\u0646\u0631\u0627\u0633\u062a"
+    ],
+    "name:ast_x_preferred":[
+        "Tamanrasset"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0645\u0646\u0631\u0627\u0633\u062a"
     ],
@@ -171,6 +177,9 @@
     "name:zho_x_preferred":[
         "\u5854\u66fc\u62c9\u585e\u7279"
     ],
+    "name:zul_x_preferred":[
+        "Tamanrasset"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
     "ne:ADM0_A3":"DZA",
@@ -302,7 +311,7 @@
         }
     ],
     "wof:id":1141909397,
-    "wof:lastmodified":1636501724,
+    "wof:lastmodified":1690875566,
     "wof:name":"Tamanrasset",
     "wof:parent_id":85670735,
     "wof:placetype":"locality",

--- a/data/114/190/939/9/1141909399.geojson
+++ b/data/114/190/939/9/1141909399.geojson
@@ -21,8 +21,17 @@
     "name:ara_x_preferred":[
         "\u063a\u0631\u062f\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u063a\u0631\u062f\u0627\u064a\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Ghardaia"
+    ],
     "name:azb_x_preferred":[
         "\u063a\u0631\u062f\u0627\u06cc\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Q\u0259rdaya"
     ],
     "name:ben_x_preferred":[
         "\u0997\u09be\u09b0\u09cd\u09a1\u09bf\u09af\u09bc\u09be"
@@ -47,6 +56,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03b1\u03c1\u03bd\u03c4\u03ac\u03b9\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0393\u03ba\u03b1\u03c1\u03bd\u03c4\u03ac\u03b9\u03b1"
     ],
     "name:eng_x_preferred":[
         "Ghardaia"
@@ -78,6 +90,9 @@
     "name:hun_x_preferred":[
         "Ghardaia"
     ],
+    "name:hye_x_preferred":[
+        "\u0533\u0561\u0580\u0564\u0561\u0575\u0561"
+    ],
     "name:ind_x_preferred":[
         "Gharda\u00efa"
     ],
@@ -89,6 +104,9 @@
     ],
     "name:kab_x_preferred":[
         "Ta\u03b3erdayt"
+    ],
+    "name:kab_x_variant":[
+        "Ta\u0263erdayt"
     ],
     "name:kan_x_preferred":[
         "\u0c98\u0cbe\u0cb0\u0ccd\u0ca1\u0cbf\u0caf\u0cbe"
@@ -140,6 +158,9 @@
     ],
     "name:spa_x_preferred":[
         "Gharda\u00efa"
+    ],
+    "name:spa_x_variant":[
+        "Gardaya"
     ],
     "name:srp_x_preferred":[
         "\u0413\u0430\u0440\u0434\u0430\u0458\u0430"
@@ -294,7 +315,7 @@
         }
     ],
     "wof:id":1141909399,
-    "wof:lastmodified":1636501724,
+    "wof:lastmodified":1690875565,
     "wof:name":"Ghardaia",
     "wof:parent_id":85670749,
     "wof:placetype":"locality",

--- a/data/421/166/605/421166605.geojson
+++ b/data/421/166/605/421166605.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0646\u0627\u0638\u0648\u0631\u060c\u062a\u064a\u0628\u0627\u0632\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0646\u0627\u0638\u0648\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u0627\u0638\u0648\u0631"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Nador"
+    ],
+    "name:kab_x_preferred":[
+        "Nna\u1e0dur"
     ],
     "name:nan_x_preferred":[
         "Nador"
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421166605,
-    "wof:lastmodified":1566583481,
+    "wof:lastmodified":1690875508,
     "wof:name":"Nador",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/166/917/421166917.geojson
+++ b/data/421/166/917/421166917.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0626\u0631 \u0627\u0644\u062c\u064a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0626\u0631 \u0627\u0644\u062c\u064a\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0626\u0631 \u062c\u06cc\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "Bir-\u0259l-Cir"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09c0\u09b0 \u098f\u09b2 \u09a1\u09bf\u09b0"
@@ -64,6 +70,9 @@
     ],
     "name:kab_x_preferred":[
         "Bir Ljir"
+    ],
+    "name:kab_x_variant":[
+        "Bir L\u01e7ir"
     ],
     "name:kan_x_preferred":[
         "\u0cac\u0cbf\u0cb0\u0ccd \u0c8e\u0cb2\u0ccd \u0ca1\u0cbf\u0c9c\u0cb0\u0ccd"
@@ -134,6 +143,9 @@
     "name:urd_x_preferred":[
         "\u0628\u06cc\u0631 \u0627\u0644 \u062f\u062c\u06cc\u0631"
     ],
+    "name:uzb_x_preferred":[
+        "Bir El Djir"
+    ],
     "name:vie_x_preferred":[
         "Bir El Djir"
     ],
@@ -189,7 +201,7 @@
         }
     ],
     "wof:id":421166917,
-    "wof:lastmodified":1566583481,
+    "wof:lastmodified":1690875508,
     "wof:name":"Bir el Djir",
     "wof:parent_id":85670689,
     "wof:placetype":"locality",

--- a/data/421/167/711/421167711.geojson
+++ b/data/421/167/711/421167711.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0632\u064a \u0631\u0627\u0634\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0632\u0649 \u0631\u0627\u0634\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0632\u06cc \u0631\u0627\u0634\u062f"
     ],
@@ -62,6 +65,9 @@
     "name:swe_x_preferred":[
         "Tizi Rached"
     ],
+    "name:uzb_x_preferred":[
+        "Tizi Rached"
+    ],
     "name:vie_x_preferred":[
         "Tizi-Rached"
     ],
@@ -70,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u63d0\u6fdf\u62c9\u820d\u5fb7"
+    ],
+    "name:zul_x_preferred":[
+        "Tizi Rached"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":421167711,
-    "wof:lastmodified":1566583485,
+    "wof:lastmodified":1690875512,
     "wof:name":"Tizi Rached",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/167/715/421167715.geojson
+++ b/data/421/167/715/421167715.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u062e\u0645\u064a\u0633 \u0627\u0644\u062e\u0634\u0646\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062e\u0645\u064a\u0633 \u0627\u0644\u062e\u0634\u0646\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062e\u0645\u06cc\u0633 \u062e\u0634\u0646\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "X\u0259ms-\u0259l-X\u0259\u015fna"
     ],
     "name:ceb_x_preferred":[
         "Khemis el Khechna"
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":421167715,
-    "wof:lastmodified":1566583485,
+    "wof:lastmodified":1690875511,
     "wof:name":"Khemis el Khechna",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/167/719/421167719.geojson
+++ b/data/421/167/719/421167719.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u064a\u0633\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u064a\u0633\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u06cc\u0633\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "Y\u0259sr"
+    ],
+    "name:ceb_x_preferred":[
+        "Isser"
     ],
     "name:deu_x_preferred":[
         "Isser"
@@ -67,6 +76,9 @@
     ],
     "name:spa_x_preferred":[
         "Issers"
+    ],
+    "name:swe_x_preferred":[
+        "Isser"
     ],
     "name:und_x_variant":[
         "Isserville"
@@ -122,7 +134,7 @@
         }
     ],
     "wof:id":421167719,
-    "wof:lastmodified":1566583485,
+    "wof:lastmodified":1690875512,
     "wof:name":"Isser",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/167/721/421167721.geojson
+++ b/data/421/167/721/421167721.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u062d\u0627\u0645\u0629 \u0628\u0648\u0632\u064a\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u0627\u0645\u0647 \u0628\u0648\u0632\u064a\u0627\u0646"
+    ],
     "name:ceb_x_preferred":[
         "Hamma Bouziane"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Hamma Bouziane"
+    ],
+    "name:kab_x_preferred":[
+        "\u1e24amma Buzeyyan"
     ],
     "name:msa_x_preferred":[
         "Hamma Bouziane"
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":421167721,
-    "wof:lastmodified":1566583485,
+    "wof:lastmodified":1690875512,
     "wof:name":"Hamma Bouziane",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",

--- a/data/421/167/725/421167725.geojson
+++ b/data/421/167/725/421167725.geojson
@@ -23,11 +23,17 @@
     "name:ara_x_variant":[
         "\u0628\u0644\u062f\u064a\u0629 \u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627\u0621"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062f\u0627\u0631 \u0627\u0644\u0628\u064a\u0636\u0627\u0621"
+    ],
     "name:cat_x_preferred":[
         "Dar El Be\u00efda"
     ],
     "name:ceb_x_preferred":[
         "Dar el Be\u00efda"
+    ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03b1\u03c1 \u0395\u03bb \u039c\u03c0\u03b5\u03ca\u03bd\u03c4\u03ac"
     ],
     "name:eng_x_preferred":[
         "Dar El Be\u00efda"
@@ -67,6 +73,9 @@
     ],
     "name:swe_x_preferred":[
         "Dar el Be\u00efda"
+    ],
+    "name:tur_x_preferred":[
+        "Dar\u00fc'l-Beyza"
     ],
     "name:und_x_variant":[
         "Maison Blanche"
@@ -123,7 +132,7 @@
         }
     ],
     "wof:id":421167725,
-    "wof:lastmodified":1566583484,
+    "wof:lastmodified":1690875511,
     "wof:name":"Dar el Beida",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/167/727/421167727.geojson
+++ b/data/421/167/727/421167727.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0642\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0642\u0631\u0647"
+    ],
     "name:cat_x_preferred":[
         "Bougara"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:ita_x_preferred":[
         "Buqara"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d6\u30ac\u30e9"
     ],
     "name:kab_x_preferred":[
         "Bugerra"
@@ -69,6 +75,9 @@
         "Bougara"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Bougara"
+    ],
+    "name:zul_x_preferred":[
         "Bougara"
     ],
     "qs:gn_country":"DZ",
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":421167727,
-    "wof:lastmodified":1566583485,
+    "wof:lastmodified":1690875513,
     "wof:name":"Bougara",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/167/729/421167729.geojson
+++ b/data/421/167/729/421167729.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u0645\u0644\u062d"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0645\u0644\u062d"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0645\u0644\u062d"
+    ],
+    "name:ceb_x_preferred":[
+        "'A\u00efn el Melh"
     ],
     "name:eng_x_preferred":[
         "A\u00efn El Melh"
@@ -35,6 +41,9 @@
     "name:ita_x_preferred":[
         "A\u00efn El Melh"
     ],
+    "name:kab_x_preferred":[
+        "\u0190in Lmel\u1e25"
+    ],
     "name:msa_x_preferred":[
         "A\u00efn El Melh"
     ],
@@ -43,6 +52,9 @@
     ],
     "name:nld_x_preferred":[
         "A\u00efn El Melh"
+    ],
+    "name:pol_x_preferred":[
+        "Ajn al-Milh"
     ],
     "name:por_x_preferred":[
         "A\u00efn El Melh"
@@ -56,8 +68,14 @@
     "name:spa_x_preferred":[
         "A\u00efn El Melh"
     ],
+    "name:swe_x_preferred":[
+        "'A\u00efn el Melh"
+    ],
     "name:und_x_variant":[
         "A\u00efne Melah"
+    ],
+    "name:uzb_x_preferred":[
+        "Ain El Melh"
     ],
     "name:vie_x_preferred":[
         "Ain El Melh"
@@ -107,7 +125,7 @@
         }
     ],
     "wof:id":421167729,
-    "wof:lastmodified":1566583485,
+    "wof:lastmodified":1690875513,
     "wof:name":"'Ain el Melh",
     "wof:parent_id":85670841,
     "wof:placetype":"locality",

--- a/data/421/168/053/421168053.geojson
+++ b/data/421/168/053/421168053.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0644\u064a\u0639\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0642\u0644\u064a\u0639\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0644\u06cc\u0639\u0647"
     ],
@@ -62,6 +65,9 @@
     "name:ron_x_variant":[
         "Kolea"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u043b\u0435\u0430"
+    ],
     "name:spa_x_preferred":[
         "Kol\u00e9a"
     ],
@@ -73,6 +79,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Kol\u00e9a"
+    ],
+    "name:zho_x_preferred":[
+        "\u514b\u96f7\u963f"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421168053,
-    "wof:lastmodified":1566583480,
+    "wof:lastmodified":1690875507,
     "wof:name":"Kolea",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/168/189/421168189.geojson
+++ b/data/421/168/189/421168189.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0632\u0631\u064a\u0628\u0629 \u0627\u0644\u0648\u0627\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0632\u0631\u064a\u0628\u0647 \u0627\u0644\u0648\u0627\u062f\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Zeribet el Oued"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:ita_x_preferred":[
         "Zeribet El Oued"
+    ],
+    "name:kab_x_preferred":[
+        "Zribet Lwad"
     ],
     "name:msa_x_preferred":[
         "Zeribet El Oued"
@@ -60,6 +66,9 @@
         "Zeribet El Oued"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Zeribet El Oued"
+    ],
+    "name:zul_x_preferred":[
         "Zeribet El Oued"
     ],
     "ne:ADM0CAP":0.0,
@@ -206,7 +215,7 @@
         }
     ],
     "wof:id":421168189,
-    "wof:lastmodified":1582348644,
+    "wof:lastmodified":1690875507,
     "wof:name":"Zeribet el Oued",
     "wof:parent_id":85670827,
     "wof:placetype":"locality",

--- a/data/421/168/191/421168191.geojson
+++ b/data/421/168/191/421168191.geojson
@@ -20,7 +20,16 @@
     "name:ara_x_preferred":[
         "\u0637\u0648\u0644\u0642\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0637\u0648\u0644\u0642\u0647"
+    ],
+    "name:cat_x_preferred":[
+        "Tolga"
+    ],
     "name:ceb_x_preferred":[
+        "Tolga"
+    ],
+    "name:deu_x_preferred":[
         "Tolga"
     ],
     "name:eng_x_preferred":[
@@ -66,6 +75,9 @@
         "Tolga"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Tolga"
+    ],
+    "name:zul_x_preferred":[
         "Tolga"
     ],
     "qs:gn_country":"DZ",
@@ -114,7 +126,7 @@
         }
     ],
     "wof:id":421168191,
-    "wof:lastmodified":1566583480,
+    "wof:lastmodified":1690875507,
     "wof:name":"Tolga",
     "wof:parent_id":85670827,
     "wof:placetype":"locality",

--- a/data/421/168/285/421168285.geojson
+++ b/data/421/168/285/421168285.geojson
@@ -23,8 +23,17 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0628\u0648\u064a\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u0648\u064a\u0631\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Bou\u00efra"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u06cc\u0631\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Buira"
     ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u0411\u0443\u0456\u0440\u0430"
@@ -38,6 +47,9 @@
     "name:cat_x_preferred":[
         "Prov\u00edncia de Bouira"
     ],
+    "name:cat_x_variant":[
+        "Bouira"
+    ],
     "name:ceb_x_preferred":[
         "Wilaya de Bouira"
     ],
@@ -46,6 +58,9 @@
     ],
     "name:deu_x_preferred":[
         "Bouira"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03c5\u03af\u03c1\u03b1"
     ],
     "name:eng_x_preferred":[
         "Bou\u00efra"
@@ -59,8 +74,14 @@
     "name:fas_x_preferred":[
         "\u0628\u0648\u06cc\u0631\u0647"
     ],
+    "name:fin_x_preferred":[
+        "Bouira"
+    ],
     "name:fra_x_preferred":[
         "Bouira"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u0578\u0582\u056b\u0580\u0561"
     ],
     "name:ita_x_preferred":[
         "Bouira"
@@ -104,11 +125,17 @@
     "name:spa_x_variant":[
         "Bouira"
     ],
+    "name:swa_x_preferred":[
+        "Bouira"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0443\u0457\u0440\u0430"
     ],
     "name:urd_x_preferred":[
         "\u0628\u0648\u06cc\u0631\u06c1"
+    ],
+    "name:uzb_x_preferred":[
+        "Buira"
     ],
     "name:vie_x_preferred":[
         "Bouira"
@@ -118,6 +145,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e03\u7ef4\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Bou\u00efra"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -161,7 +191,7 @@
         }
     ],
     "wof:id":421168285,
-    "wof:lastmodified":1566583481,
+    "wof:lastmodified":1690875508,
     "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0628\u0648\u064a\u0631\u0629",
     "wof:parent_id":85670823,
     "wof:placetype":"locality",

--- a/data/421/169/023/421169023.geojson
+++ b/data/421/169/023/421169023.geojson
@@ -26,14 +26,23 @@
     "name:ara_x_variant":[
         "\u0633\u0643\u064a\u0643\u062f\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0643\u064a\u0643\u062f\u0647"
+    ],
     "name:ast_x_preferred":[
         "Skikda"
     ],
     "name:azb_x_preferred":[
         "\u0633\u06a9\u06cc\u06a9\u062f\u0647"
     ],
+    "name:aze_x_preferred":[
+        "Skikda"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u043a\u0456\u043a\u0434\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0421\u043a\u0456\u043a\u0434\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09cd\u0995\u09bf\u0995\u09a6\u09be"
@@ -65,10 +74,16 @@
     "name:ell_x_preferred":[
         "\u03a3\u03ba\u03af\u03ba\u03bd\u03c4\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u03a3\u03ba\u03b9\u03ba\u03bd\u03c4\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Skikda"
     ],
     "name:epo_x_preferred":[
+        "Skikda"
+    ],
+    "name:eus_x_preferred":[
         "Skikda"
     ],
     "name:fas_x_preferred":[
@@ -134,6 +149,9 @@
     "name:mkd_x_preferred":[
         "\u0421\u043a\u0438\u043a\u0434\u0430"
     ],
+    "name:mlt_x_preferred":[
+        "Skikda"
+    ],
     "name:msa_x_preferred":[
         "Skikda"
     ],
@@ -167,8 +185,14 @@
     "name:spa_x_preferred":[
         "Skikda"
     ],
+    "name:swa_x_preferred":[
+        "Skikda"
+    ],
     "name:swe_x_preferred":[
         "Skikda"
+    ],
+    "name:szl_x_preferred":[
+        "Sukajkida"
     ],
     "name:tam_x_preferred":[
         "\u0bb8\u0bcd\u0b95\u0bbf\u0b95\u0bcd\u0b9f\u0bcd\u0b9f\u0bbe"
@@ -190,6 +214,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0633\u06a9\u06cc\u06a9\u062f\u0627"
+    ],
+    "name:uzb_x_preferred":[
+        "Skikda"
     ],
     "name:vie_x_preferred":[
         "Skikda"
@@ -337,7 +364,7 @@
         }
     ],
     "wof:id":421169023,
-    "wof:lastmodified":1566583486,
+    "wof:lastmodified":1690875513,
     "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0633\u0643\u064a\u0643\u062f\u0629",
     "wof:parent_id":85670727,
     "wof:placetype":"locality",

--- a/data/421/169/025/421169025.geojson
+++ b/data/421/169/025/421169025.geojson
@@ -21,16 +21,32 @@
         "\u0633\u064a\u062f\u064a \u0628\u0644\u0639\u0628\u0627\u0633"
     ],
     "name:ara_x_variant":[
-        "\u0648\u0644\u0627\u064a\u0629 \u0633\u064a\u062f\u064a \u0628\u0644\u0639\u0628\u0627\u0633"
+        "\u0648\u0644\u0627\u064a\u0629 \u0633\u064a\u062f\u064a \u0628\u0644\u0639\u0628\u0627\u0633",
+        "\u0627\u0644\u062c\u0632\u0627\u0626\u0631 \u0627\u0644\u0639\u0627\u0635\u0645\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0628\u0644\u0639\u0628\u0627\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Sidi Bel Abb\u00e8s"
     ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0628\u0644\u0639\u0628\u0627\u0633"
     ],
+    "name:aze_x_preferred":[
+        "Sidi-B\u0259l-Abbas"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0456\u0434\u044b-\u0411\u0435\u043b\u044c-\u0410\u0431\u0435\u0441"
     ],
+    "name:bel_x_variant":[
+        "\u0421\u0456\u0434\u044b-\u0411\u0435\u043b\u044c-\u0410\u0431\u0435\u0441"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09bf\u09a6\u09bf \u09ac\u09c7\u09b2 \u0986\u09ac\u09c7\u09b8"
+    ],
+    "name:ben_x_variant":[
+        "\u09b8\u09bf\u09a6\u09bf \u09ac\u09c7\u09b2 \u0986\u09ac\u09cd\u09ac\u09c7\u09b8"
     ],
     "name:bre_x_preferred":[
         "Sidi Bel Abb\u00e8s"
@@ -86,6 +102,12 @@
     "name:fra_x_variant":[
         "Sidi Bel Abb\u00e8s"
     ],
+    "name:frr_x_preferred":[
+        "Sidi Bel Abb\u00e8s"
+    ],
+    "name:gle_x_preferred":[
+        "Sidi Bel Abb\u00e8s"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0abf\u0aa6\u0ac0 \u0aac\u0ac7\u0ab2 \u0a85\u0aac\u0acd\u0aac\u0ac7\u0ab8"
     ],
@@ -94,6 +116,9 @@
     ],
     "name:hin_x_preferred":[
         "\u0938\u093f\u0926\u0940 \u092c\u0947\u0932 \u0905\u092c\u0947\u0938"
+    ],
+    "name:hye_x_preferred":[
+        "\u054d\u056b\u0564\u056b \u0532\u0565\u056c \u0531\u0562\u0561\u057d"
     ],
     "name:ind_x_preferred":[
         "Sidi Bilabbas"
@@ -106,6 +131,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b7\u30c7\u30a3\u30fb\u30d9\u30eb\u30fb\u30a2\u30d9\u30b9"
+    ],
+    "name:jpn_x_variant":[
+        "\u30b7\u30c7\u30a3\u30fb\u30d9\u30eb\u30fb\u30a2\u30c3\u30d9\u30b9"
     ],
     "name:kab_x_preferred":[
         "Sidi Bel\u025bebbas"
@@ -146,6 +174,9 @@
     "name:nob_x_preferred":[
         "Sidi bel Abb\u00e8s"
     ],
+    "name:oci_x_preferred":[
+        "Sidi Bel Abbas"
+    ],
     "name:pnb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0628\u0644\u0639\u0628\u0627\u0633"
     ],
@@ -175,6 +206,9 @@
     ],
     "name:spa_x_preferred":[
         "Sidi Bel Abbes"
+    ],
+    "name:swa_x_preferred":[
+        "Sidi Bel Abb\u00e8s"
     ],
     "name:swe_x_preferred":[
         "Sidi Bel Abb\u00e8s"
@@ -346,7 +380,7 @@
         }
     ],
     "wof:id":421169025,
-    "wof:lastmodified":1566583486,
+    "wof:lastmodified":1690875513,
     "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0633\u064a\u062f\u064a \u0628\u0644\u0639\u0628\u0627\u0633",
     "wof:parent_id":85670691,
     "wof:placetype":"locality",

--- a/data/421/169/027/421169027.geojson
+++ b/data/421/169/027/421169027.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0635\u0627\u0644\u062d"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0635\u0627\u0644\u062d"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0635\u0627\u0644\u062d"
+    ],
+    "name:aze_x_preferred":[
+        "\u0130n-Salah"
     ],
     "name:cat_x_preferred":[
         "In Salah"
@@ -34,6 +40,9 @@
     ],
     "name:deu_x_preferred":[
         "In Salah"
+    ],
+    "name:ell_x_preferred":[
+        "\u0399\u03bd \u03a3\u03b1\u03bb\u03ac\u03c7"
     ],
     "name:eng_x_preferred":[
         "In Salah"
@@ -109,6 +118,9 @@
     ],
     "name:vie_x_preferred":[
         "In Salah"
+    ],
+    "name:yue_x_preferred":[
+        "\u56e0\u85a9\u62c9"
     ],
     "name:zho_x_preferred":[
         "\u56e0\u8428\u62c9\u8d6b"
@@ -250,7 +262,7 @@
         }
     ],
     "wof:id":421169027,
-    "wof:lastmodified":1566583486,
+    "wof:lastmodified":1690875514,
     "wof:name":"Ain Salah",
     "wof:parent_id":85670735,
     "wof:placetype":"locality",

--- a/data/421/170/449/421170449.geojson
+++ b/data/421/170/449/421170449.geojson
@@ -29,11 +29,23 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u0648\u0647\u0631\u0627\u0646"
     ],
+    "name:arq_x_preferred":[
+        "\u0648\u0647\u0631\u0627\u0646"
+    ],
+    "name:ary_x_preferred":[
+        "\u0648\u0647\u0631\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0648\u0647\u0631\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "Or\u00e1n"
     ],
     "name:azb_x_preferred":[
         "\u0648\u0647\u0631\u0627\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "V\u0259hran"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0440\u0430\u043d"
@@ -107,6 +119,12 @@
     "name:fra_x_preferred":[
         "Oran"
     ],
+    "name:frr_x_preferred":[
+        "Oran"
+    ],
+    "name:gle_x_preferred":[
+        "Oran"
+    ],
     "name:glg_x_preferred":[
         "Or\u00e1n"
     ],
@@ -137,6 +155,9 @@
     "name:hye_x_preferred":[
         "\u0555\u0580\u0561\u0576"
     ],
+    "name:ido_x_preferred":[
+        "Oran"
+    ],
     "name:ind_x_preferred":[
         "Oran"
     ],
@@ -164,11 +185,17 @@
     "name:kor_x_preferred":[
         "\uc624\ub791"
     ],
+    "name:kur_x_preferred":[
+        "Oran"
+    ],
     "name:lad_x_preferred":[
         "Oran"
     ],
     "name:lat_x_preferred":[
         "Oran"
+    ],
+    "name:lat_x_variant":[
+        "Oranum"
     ],
     "name:lav_x_preferred":[
         "Or\u0101na"
@@ -185,8 +212,14 @@
     "name:mar_x_preferred":[
         "\u0913\u0930\u093e\u0928"
     ],
+    "name:mdf_x_preferred":[
+        "\u041e\u0440\u0430\u043d"
+    ],
     "name:mkd_x_preferred":[
         "\u041e\u0440\u0430\u043d"
+    ],
+    "name:mlt_x_preferred":[
+        "Oran"
     ],
     "name:mon_x_preferred":[
         "\u041e\u0440\u0430\u043d"
@@ -275,6 +308,9 @@
     "name:twi_x_preferred":[
         "Oran"
     ],
+    "name:uig_x_preferred":[
+        "\u06cb\u06d5\u06be\u0631\u0627\u0646"
+    ],
     "name:ukr_x_preferred":[
         "\u041e\u0440\u0430\u043d"
     ],
@@ -287,6 +323,12 @@
     "name:uzb_x_preferred":[
         "Oran"
     ],
+    "name:uzb_x_variant":[
+        "Vahron"
+    ],
+    "name:vec_x_preferred":[
+        "Orano"
+    ],
     "name:vie_x_preferred":[
         "Oran"
     ],
@@ -298,6 +340,9 @@
     ],
     "name:wuu_x_preferred":[
         "\u74e6\u8d6b\u5170"
+    ],
+    "name:yue_x_preferred":[
+        "\u5967\u862d"
     ],
     "name:zho_x_preferred":[
         "\u74e6\u8d6b\u862d"
@@ -447,7 +492,7 @@
         }
     ],
     "wof:id":421170449,
-    "wof:lastmodified":1636501721,
+    "wof:lastmodified":1690875531,
     "wof:megacity":1,
     "wof:name":"Oran",
     "wof:parent_id":85670689,

--- a/data/421/170/533/421170533.geojson
+++ b/data/421/170/533/421170533.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0644\u0627\u0631\u0647\u0627\u0637"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u0631\u0647\u0627\u0637"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u0627\u0631\u0647\u0627\u0637"
     ],
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421170533,
-    "wof:lastmodified":1566583500,
+    "wof:lastmodified":1690875530,
     "wof:name":"Larhat",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/170/775/421170775.geojson
+++ b/data/421/170/775/421170775.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0628\u062f\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0628\u062f\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0628\u062f\u0648"
     ],
@@ -68,10 +71,16 @@
     "name:swe_x_preferred":[
         "Sebdou"
     ],
+    "name:uzb_x_preferred":[
+        "Sebdou"
+    ],
     "name:vie_x_preferred":[
         "Sebdou"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Sebdou"
+    ],
+    "name:zul_x_preferred":[
         "Sebdou"
     ],
     "qs:gn_country":"DZ",
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421170775,
-    "wof:lastmodified":1566583500,
+    "wof:lastmodified":1690875531,
     "wof:name":"Debdou",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/421/170/825/421170825.geojson
+++ b/data/421/170/825/421170825.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0639\u0628\u0627\u0633\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0639\u0628\u0627\u0633\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0639\u0628\u0627\u0633\u0647"
     ],
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421170825,
-    "wof:lastmodified":1566583500,
+    "wof:lastmodified":1690875531,
     "wof:name":"'Ain Abessa",
     "wof:parent_id":85670845,
     "wof:placetype":"locality",

--- a/data/421/172/101/421172101.geojson
+++ b/data/421/172/101/421172101.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u062d\u062c\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u062d\u062c\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u062d\u062c\u0631"
+    ],
+    "name:ceb_x_preferred":[
+        "'A\u00efn el Hadjar"
     ],
     "name:eng_x_preferred":[
         "A\u00efn El Hadjar"
@@ -40,6 +46,9 @@
     ],
     "name:kab_x_preferred":[
         "\u0190in Le\u1e25jar"
+    ],
+    "name:kab_x_variant":[
+        "\u0190in Le\u1e25\u01e7er"
     ],
     "name:msa_x_preferred":[
         "Ain El Hadjar"
@@ -64,6 +73,9 @@
     ],
     "name:spa_x_preferred":[
         "A\u00efn El Hadjar"
+    ],
+    "name:swe_x_preferred":[
+        "'A\u00efn el Hadjar"
     ],
     "name:und_x_variant":[
         "A\u00efne el Hadjar"
@@ -119,7 +131,7 @@
         }
     ],
     "wof:id":421172101,
-    "wof:lastmodified":1566583493,
+    "wof:lastmodified":1690875521,
     "wof:name":"'Ain el Hadjar",
     "wof:parent_id":85670797,
     "wof:placetype":"locality",

--- a/data/421/172/687/421172687.geojson
+++ b/data/421/172/687/421172687.geojson
@@ -45,10 +45,14 @@
         "Basilique Notre-Dame d'Afrique"
     ],
     "name:fra_x_variant":[
-        "basilique Notre-Dame d'Afrique"
+        "basilique Notre-Dame d'Afrique",
+        "basilique Notre-Dame-d'Afrique"
     ],
     "name:hrv_x_preferred":[
         "Bazilika Majke Bo\u017eje Afri\u010dke u Al\u017eiru"
+    ],
+    "name:ind_x_preferred":[
+        "Basilika Bunda Maria dari Afrika"
     ],
     "name:ita_x_preferred":[
         "Basilica di Nostra Signora d'Africa"
@@ -70,6 +74,9 @@
     ],
     "name:swe_x_preferred":[
         "Notre Dame d'Afrique"
+    ],
+    "name:tur_x_preferred":[
+        "Afrika Meryem Ana Bazilikas\u0131"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u043e\u0431\u043e\u0440 \u0410\u0444\u0440\u0438\u043a\u0430\u043d\u0441\u044c\u043a\u043e\u0457 \u0411\u043e\u0433\u043e\u043c\u0430\u0442\u0435\u0440\u0456"
@@ -120,7 +127,7 @@
         }
     ],
     "wof:id":421172687,
-    "wof:lastmodified":1566583493,
+    "wof:lastmodified":1690875521,
     "wof:name":"Notre Dame D'afrique",
     "wof:parent_id":85670761,
     "wof:placetype":"locality",

--- a/data/421/172/707/421172707.geojson
+++ b/data/421/172/707/421172707.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u062f\u064a\u0629 \u0628\u0631\u062c \u0627\u0644\u0628\u062d\u0631\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u062c \u0627\u0644\u0628\u062d\u0631\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u062c \u0628\u062d\u0631\u06cc"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03c1\u03c4\u03b6 \u0395\u03bb \u039c\u03c0\u03b1\u03c7\u03c1\u03af"
     ],
     "name:eng_x_preferred":[
         "Bordj El Bahri"
@@ -34,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Bordj El Bahri"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30eb\u30b8\u30a7\u6c96\u5408"
     ],
     "name:kab_x_preferred":[
         "Burj Lbe\u1e25ri"
@@ -55,6 +64,9 @@
     ],
     "name:spa_x_preferred":[
         "Bordj El Bahri"
+    ],
+    "name:tur_x_preferred":[
+        "Burc\u00fc'l-Bahri"
     ],
     "name:und_x_variant":[
         "Matifou"
@@ -116,7 +128,7 @@
         }
     ],
     "wof:id":421172707,
-    "wof:lastmodified":1566583493,
+    "wof:lastmodified":1690875520,
     "wof:name":"Bordj el Bahri",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/172/709/421172709.geojson
+++ b/data/421/172/709/421172709.geojson
@@ -16,11 +16,53 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Ben Aknoun"
+    ],
     "name:ara_x_preferred":[
         "\u0628\u0644\u062f\u064a\u0629 \u0628\u0646 \u0639\u0643\u0646\u0648\u0646"
     ],
+    "name:ara_x_variant":[
+        "\u0628\u0646 \u0639\u0643\u0646\u0648\u0646"
+    ],
+    "name:arg_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646 \u0639\u0643\u0646\u0648\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Ben Aknoun"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646 \u0639\u06a9\u0646\u0648\u0646"
+    ],
+    "name:bar_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:bos_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:bre_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:cat_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:ces_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:cor_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:cos_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:cym_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:dan_x_preferred":[
+        "Ben Aknoun"
     ],
     "name:deu_x_preferred":[
         "Ben Aknoun"
@@ -28,17 +70,71 @@
     "name:eng_x_preferred":[
         "Ben Aknoun"
     ],
+    "name:epo_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:est_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:eus_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:fao_x_preferred":[
+        "Ben Aknoun"
+    ],
     "name:fas_x_preferred":[
         "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0628\u0646 \u0639\u06a9\u0646\u0648\u0646"
     ],
+    "name:fin_x_preferred":[
+        "Ben Aknoun"
+    ],
     "name:fra_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:gla_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:gle_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:glg_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:glv_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:hrv_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:hun_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:ind_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:isl_x_preferred":[
         "Ben Aknoun"
     ],
     "name:ita_x_preferred":[
         "Ben Aknoun"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d9\u30f3\u30fb\u30a2\u30af\u30cc\u30f3"
+    ],
     "name:kab_x_preferred":[
         "Ben\u025beknun"
+    ],
+    "name:lav_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:lit_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:ltz_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:mlt_x_preferred":[
+        "Ben Aknoun"
     ],
     "name:msa_x_preferred":[
         "Ben Aknoun"
@@ -49,7 +145,25 @@
     "name:nld_x_preferred":[
         "Ben Aknoun"
     ],
+    "name:nno_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:nrm_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:oci_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:pms_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:pol_x_preferred":[
+        "Ben Aknoun"
+    ],
     "name:por_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:roh_x_preferred":[
         "Ben Aknoun"
     ],
     "name:ron_x_preferred":[
@@ -58,7 +172,25 @@
     "name:rus_x_preferred":[
         "\u0411\u0435\u043d-\u0410\u043a\u043d\u0443\u043d"
     ],
+    "name:slk_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:slv_x_preferred":[
+        "Ben Aknoun"
+    ],
     "name:spa_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:sqi_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:swe_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:tah_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:tur_x_preferred":[
         "Ben Aknoun"
     ],
     "name:und_x_variant":[
@@ -70,7 +202,13 @@
     "name:vie_x_preferred":[
         "Ben Aknoun"
     ],
+    "name:wln_x_preferred":[
+        "Ben Aknoun"
+    ],
     "name:zho_min_nan_x_preferred":[
+        "Ben Aknoun"
+    ],
+    "name:zul_x_preferred":[
         "Ben Aknoun"
     ],
     "qs:gn_country":"DZ",
@@ -119,7 +257,7 @@
         }
     ],
     "wof:id":421172709,
-    "wof:lastmodified":1566583493,
+    "wof:lastmodified":1690875520,
     "wof:name":"Ben 'Akno\u00fbn",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/173/951/421173951.geojson
+++ b/data/421/173/951/421173951.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u0627\u0642\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u0627\u0642\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u0627\u0642\u06cc"
     ],
@@ -41,6 +44,9 @@
     "name:ita_x_preferred":[
         "Baraki"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d0\u30e9\u30ad"
+    ],
     "name:kab_x_preferred":[
         "Berraqi"
     ],
@@ -54,6 +60,9 @@
         "Baraki"
     ],
     "name:nld_x_preferred":[
+        "Baraki"
+    ],
+    "name:nob_x_preferred":[
         "Baraki"
     ],
     "name:pol_x_preferred":[
@@ -70,6 +79,9 @@
     ],
     "name:swe_x_preferred":[
         "Baraki"
+    ],
+    "name:tur_x_preferred":[
+        "Buraki"
     ],
     "name:urd_x_preferred":[
         "\u0628\u0631\u0627\u0642\u06cc\u060c \u0627\u0644\u062c\u0632\u0627\u0626\u0631"
@@ -135,7 +147,7 @@
         }
     ],
     "wof:id":421173951,
-    "wof:lastmodified":1566583491,
+    "wof:lastmodified":1690875519,
     "wof:name":"Baraki",
     "wof:parent_id":85670761,
     "wof:placetype":"locality",

--- a/data/421/173/953/421173953.geojson
+++ b/data/421/173/953/421173953.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0630\u0631\u0627\u0639 \u0627\u0644\u0645\u064a\u0632\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0630\u0631\u0627\u0639 \u0627\u0644\u0645\u064a\u0632\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0630\u0631\u0627\u0639 \u0645\u06cc\u0632\u0627\u0646"
     ],
@@ -74,11 +77,17 @@
     "name:und_x_variant":[
         "Dra el Mizan"
     ],
+    "name:uzb_x_preferred":[
+        "Draa El Mizan"
+    ],
     "name:vie_x_preferred":[
         "Draa El Mizan"
     ],
     "name:zho_x_preferred":[
         "\u5fb7\u62c9\u7c73\u8d0a"
+    ],
+    "name:zul_x_preferred":[
+        "Dra\u00e2 El Mizan"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -126,7 +135,7 @@
         }
     ],
     "wof:id":421173953,
-    "wof:lastmodified":1566583490,
+    "wof:lastmodified":1690875519,
     "wof:name":"Draa el Mizan",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/173/955/421173955.geojson
+++ b/data/421/173/955/421173955.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0632\u0648\u0646\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0632\u0648\u0646\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u0632\u0648\u0646\u0647"
     ],
@@ -44,6 +47,9 @@
     "name:ita_x_preferred":[
         "Mazouna"
     ],
+    "name:kab_x_preferred":[
+        "Mazuna"
+    ],
     "name:msa_x_preferred":[
         "Mazouna"
     ],
@@ -63,6 +69,9 @@
         "Mazouna"
     ],
     "name:swe_x_preferred":[
+        "Mazouna"
+    ],
+    "name:uzb_x_preferred":[
         "Mazouna"
     ],
     "name:vie_x_preferred":[
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421173955,
-    "wof:lastmodified":1566583491,
+    "wof:lastmodified":1690875519,
     "wof:name":"Mazouna",
     "wof:parent_id":85670791,
     "wof:placetype":"locality",

--- a/data/421/174/317/421174317.geojson
+++ b/data/421/174/317/421174317.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0631\u0627\u0642\u0629"
     ],
+    "name:arq_x_preferred":[
+        "\u0627\u0644\u0634\u0631\u0627\u06a8\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0631\u0627\u0642\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0631\u0627\u0642\u0647"
     ],
@@ -31,6 +37,9 @@
     ],
     "name:eng_x_preferred":[
         "Ch\u00e9raga"
+    ],
+    "name:eng_x_variant":[
+        "Cheraga"
     ],
     "name:fas_x_preferred":[
         "\u0634\u0631\u0627\u0642\u0647"
@@ -64,6 +73,9 @@
     ],
     "name:swe_x_preferred":[
         "Cheraga"
+    ],
+    "name:tur_x_preferred":[
+        "\u015eeraka"
     ],
     "name:und_x_variant":[
         "Cheragas"
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":421174317,
-    "wof:lastmodified":1566583489,
+    "wof:lastmodified":1690875517,
     "wof:name":"Cheraga",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/174/319/421174319.geojson
+++ b/data/421/174/319/421174319.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0631\u0639\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0631\u0639\u0648\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0641\u0631\u0639\u0648\u0646"
     ],
@@ -50,6 +53,9 @@
     "name:nld_x_preferred":[
         "Feraoun"
     ],
+    "name:pol_x_preferred":[
+        "Ferraoun"
+    ],
     "name:por_x_preferred":[
         "Feraoun"
     ],
@@ -62,6 +68,9 @@
     "name:swe_x_preferred":[
         "Feraoun"
     ],
+    "name:uzb_x_preferred":[
+        "Feraun"
+    ],
     "name:vie_x_preferred":[
         "Feraoun"
     ],
@@ -70,6 +79,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8cbb\u62c9\u96f2"
+    ],
+    "name:zul_x_preferred":[
+        "Feraoun"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -117,7 +129,7 @@
         }
     ],
     "wof:id":421174319,
-    "wof:lastmodified":1566583489,
+    "wof:lastmodified":1690875517,
     "wof:name":"Feraoun",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/174/321/421174321.geojson
+++ b/data/421/174/321/421174321.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u062c \u0627\u0644\u0643\u064a\u0641\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u062c \u0627\u0644\u0643\u064a\u0641\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u062c \u0627\u0644\u06a9\u06cc\u0641\u0627\u0646"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:deu_x_preferred":[
         "Burj-al-Kiffan"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03c1\u03c4\u03b6 \u0395\u03bb \u039a\u03b9\u03c6\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Bordj El Kiffan"
@@ -46,6 +52,9 @@
     ],
     "name:ita_x_preferred":[
         "Bordj El Kiffan"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30dc\u30eb\u30b8\u30fb\u30a8\u30eb\u30fb\u30ad\u30c3\u30d5\u30a1\u30f3"
     ],
     "name:kab_x_preferred":[
         "Burj Lkifan"
@@ -63,6 +72,9 @@
         "Bordj El Kiffan"
     ],
     "name:nld_x_preferred":[
+        "Bordj El Kiffan"
+    ],
+    "name:nob_x_preferred":[
         "Bordj El Kiffan"
     ],
     "name:pol_x_preferred":[
@@ -83,6 +95,9 @@
     "name:swe_x_preferred":[
         "Bordj el Kiffan"
     ],
+    "name:tur_x_preferred":[
+        "Burc\u00fc'l-Kifan"
+    ],
     "name:und_x_variant":[
         "Fort de l\u2019Eau"
     ],
@@ -97,6 +112,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Bordj El Kiffan"
+    ],
+    "name:zho_x_preferred":[
+        "\u57fa\u51e1\u5821"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -144,7 +162,7 @@
         }
     ],
     "wof:id":421174321,
-    "wof:lastmodified":1566583489,
+    "wof:lastmodified":1690875517,
     "wof:name":"Bordj el Kiffan",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/174/565/421174565.geojson
+++ b/data/421/174/565/421174565.geojson
@@ -20,11 +20,17 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u062c \u0632\u0645\u0648\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u062c \u0632\u0645\u0648\u0631\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u062c \u0632\u0645\u0648\u0631\u0647"
     ],
     "name:ceb_x_preferred":[
         "Bordj Zemoura"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03c1\u03c4\u03b6 \u0396\u03b5\u03bc\u03bf\u03c5\u03c1\u03ac"
     ],
     "name:eng_x_preferred":[
         "Bordj Zemoura"
@@ -37,6 +43,9 @@
     ],
     "name:ita_x_preferred":[
         "Bordj Zemoura"
+    ],
+    "name:kab_x_preferred":[
+        "Bur\u01e7 Zemmura"
     ],
     "name:msa_x_preferred":[
         "Bordj Zemoura"
@@ -61,6 +70,9 @@
     ],
     "name:und_x_variant":[
         "Zemmoura"
+    ],
+    "name:uzb_x_preferred":[
+        "Bordj Zemoura"
     ],
     "name:vie_x_preferred":[
         "Bordj Zemoura"
@@ -114,7 +126,7 @@
         }
     ],
     "wof:id":421174565,
-    "wof:lastmodified":1566583488,
+    "wof:lastmodified":1690875516,
     "wof:name":"Bordj Zemoura",
     "wof:parent_id":85670809,
     "wof:placetype":"locality",

--- a/data/421/174/649/421174649.geojson
+++ b/data/421/174/649/421174649.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:min_zoom":4.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:abk_x_preferred":[
+        "\u0410\u043b\u0436\u0438\u0440"
+    ],
     "name:ady_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
     ],
@@ -31,6 +34,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062c\u0632\u0627\u0626\u0631"
     ],
+    "name:ara_x_variant":[
+        "\u0627\u0644\u062c\u0632\u0627\u0626\u0631 \u0627\u0644\u0639\u0627\u0635\u0645\u0629"
+    ],
     "name:arc_x_preferred":[
         "\u0713\u0719\u0710\u0710\u072a"
     ],
@@ -40,11 +46,17 @@
     "name:arq_x_preferred":[
         "\u062f\u0652\u0632\u064e\u0627\u064a\u064e\u0631"
     ],
+    "name:ary_x_preferred":[
+        "\u0644\u062c\u0632\u0627\u0626\u0631\u200e"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u062c\u0632\u0627\u064a\u0631"
     ],
     "name:ast_x_preferred":[
         "Arxel"
+    ],
+    "name:avk_x_preferred":[
+        "Aljazair"
     ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u062c\u0632\u06cc\u0631\u0647"
@@ -57,6 +69,9 @@
     ],
     "name:bam_x_preferred":[
         "Alger"
+    ],
+    "name:ban_x_preferred":[
+        "Aljir"
     ],
     "name:bcl_x_preferred":[
         "Algiers"
@@ -223,6 +238,9 @@
     "name:ilo_x_preferred":[
         "Arhel"
     ],
+    "name:ina_x_preferred":[
+        "Alger"
+    ],
     "name:ind_x_preferred":[
         "Aljir"
     ],
@@ -319,6 +337,12 @@
     "name:mlg_x_preferred":[
         "Algiers"
     ],
+    "name:mlt_x_preferred":[
+        "Al\u0121iers"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd1\uabdc\uabd6\uabe4\uabcc\uabd4\uabc1"
+    ],
     "name:mon_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440 \u0445\u043e\u0442"
     ],
@@ -331,11 +355,17 @@
     "name:mya_x_preferred":[
         "\u1021\u101a\u103a\u101c\u1002\u103b\u102e\u1038\u101a\u102c\u1038\u1019\u103c\u102d\u102f\u1037"
     ],
+    "name:mzn_x_preferred":[
+        "\u0627\u0644\u062c\u0632\u06cc\u0631\u0647"
+    ],
     "name:nah_x_preferred":[
         "Argel"
     ],
     "name:nan_x_preferred":[
         "Algiers"
+    ],
+    "name:nav_x_preferred":[
+        "T\u00e1\u0142k\u00e1\u00e1\u02bc Dahndaa\u02bcee\u0142"
     ],
     "name:nds_x_preferred":[
         "Algier"
@@ -366,6 +396,9 @@
     ],
     "name:oss_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
+    ],
+    "name:pam_x_preferred":[
+        "Algiers"
     ],
     "name:pan_x_preferred":[
         "\u0a05\u0a32-\u0a1c\u0a1c\u0a3c\u0a3e\u0a07\u0a30"
@@ -400,6 +433,9 @@
     "name:rus_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
     ],
+    "name:sat_x_preferred":[
+        "\u1c5f\u1c5e\u1c61\u1c64\u1c6d\u1c5f\u1c68\u1c65"
+    ],
     "name:scn_x_preferred":[
         "Algeri"
     ],
@@ -409,6 +445,9 @@
     "name:sgs_x_preferred":[
         "Al\u017e\u012brs"
     ],
+    "name:shi_x_preferred":[
+        "Dzayr"
+    ],
     "name:sin_x_preferred":[
         "\u0d87\u0dbd\u0dca\u0da2\u0dd2\u0dba\u0dbb\u0dca\u0dc3\u0dca"
     ],
@@ -417,6 +456,9 @@
     ],
     "name:slv_x_preferred":[
         "Al\u017eir"
+    ],
+    "name:smn_x_preferred":[
+        "Alger"
     ],
     "name:sna_x_preferred":[
         "Algiers"
@@ -429,6 +471,9 @@
     ],
     "name:sqi_x_preferred":[
         "Algier"
+    ],
+    "name:srd_x_preferred":[
+        "Algeri"
     ],
     "name:srp_ec_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
@@ -453,6 +498,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb2\u0bcd\u0b9c\u0bbf\u0baf\u0bb0\u0bcd\u0bb8\u0bcd"
+    ],
+    "name:tat_x_preferred":[
+        "\u04d8\u043b\u0497\u04d9\u0437\u0430\u0438\u0440"
     ],
     "name:tel_x_preferred":[
         "\u0c06\u0c32\u0c4d\u0c1c\u0c40\u0c30\u0c4d\u0c38\u0c4d"
@@ -501,6 +549,9 @@
     ],
     "name:vec_x_preferred":[
         "Algeri"
+    ],
+    "name:vec_x_variant":[
+        "Alzeri"
     ],
     "name:vep_x_preferred":[
         "Al\u017eir"
@@ -695,7 +746,7 @@
         }
     ],
     "wof:id":421174649,
-    "wof:lastmodified":1608688187,
+    "wof:lastmodified":1690875516,
     "wof:megacity":1,
     "wof:name":"Algiers",
     "wof:parent_id":85670761,

--- a/data/421/174/927/421174927.geojson
+++ b/data/421/174/927/421174927.geojson
@@ -20,11 +20,17 @@
     "name:ara_x_preferred":[
         "\u0634\u0631\u0634\u0627\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0631\u0634\u0627\u0644"
+    ],
     "name:ast_x_preferred":[
         "Cherchell"
     ],
     "name:azb_x_preferred":[
         "\u0634\u0631\u0634\u0627\u0644"
+    ],
+    "name:aze_x_preferred":[
+        "\u015e\u0259r\u015fal"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0428\u044d\u0440\u0448\u044d\u043b\u044c"
@@ -38,8 +44,14 @@
     "name:ces_x_preferred":[
         "Cherchell"
     ],
+    "name:deu_x_preferred":[
+        "Cherchell"
+    ],
     "name:ell_x_preferred":[
         "\u03a4\u03c3\u03b5\u03c1\u03c4\u03c3\u03ad\u03bb\u03bb \u0391\u03bb\u03b3\u03b5\u03c1\u03af\u03b1\u03c2"
+    ],
+    "name:ell_x_variant":[
+        "\u03a3\u03b5\u03c1\u03c3\u03ad\u03bb"
     ],
     "name:eng_x_preferred":[
         "Cherchell"
@@ -67,6 +79,9 @@
     ],
     "name:hun_x_preferred":[
         "Sersel"
+    ],
+    "name:hye_x_preferred":[
+        "\u0547\u0565\u0580\u0577\u0565\u056c"
     ],
     "name:ind_x_preferred":[
         "Cherchell"
@@ -122,6 +137,9 @@
     "name:spa_x_preferred":[
         "Cherchell"
     ],
+    "name:swa_x_preferred":[
+        "Cherchell"
+    ],
     "name:swe_x_preferred":[
         "Cherchell"
     ],
@@ -142,6 +160,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6b47\u723e\u8b1d\u723e"
+    ],
+    "name:zho_x_variant":[
+        "\u820d\u5c14\u6c99\u52d2"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -184,7 +205,7 @@
         }
     ],
     "wof:id":421174927,
-    "wof:lastmodified":1566583489,
+    "wof:lastmodified":1690875517,
     "wof:name":"Cherchell",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/175/473/421175473.geojson
+++ b/data/421/175/473/421175473.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0639\u0637\u0627\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u0637\u0627\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0637\u0627\u0641"
     ],
@@ -38,6 +41,9 @@
     "name:ita_x_preferred":[
         "El Attaf"
     ],
+    "name:kab_x_preferred":[
+        "L\u025be\u1e6d\u1e6daf"
+    ],
     "name:msa_x_preferred":[
         "El Attaf"
     ],
@@ -45,6 +51,9 @@
         "El Attaf"
     ],
     "name:nld_x_preferred":[
+        "El Attaf"
+    ],
+    "name:pol_x_preferred":[
         "El Attaf"
     ],
     "name:por_x_preferred":[
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421175473,
-    "wof:lastmodified":1566583494,
+    "wof:lastmodified":1690875522,
     "wof:name":"El Attaf",
     "wof:parent_id":85670777,
     "wof:placetype":"locality",

--- a/data/421/175/989/421175989.geojson
+++ b/data/421/175/989/421175989.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0637\u0627\u0648\u0627\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0637\u0627\u0648\u0627\u0644\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0637\u0627\u0648\u0627\u0644\u06cc"
     ],
@@ -47,6 +50,9 @@
     "name:nld_x_preferred":[
         "Staou\u00e9li"
     ],
+    "name:nob_x_preferred":[
+        "Staou\u00e9li"
+    ],
     "name:por_x_preferred":[
         "Staou\u00e9li"
     ],
@@ -56,6 +62,9 @@
     "name:spa_x_preferred":[
         "Staoueli"
     ],
+    "name:tur_x_preferred":[
+        "Satvali"
+    ],
     "name:urd_x_preferred":[
         "\u0633\u0637\u0648\u0627\u0644\u06cc"
     ],
@@ -64,6 +73,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Staoueli"
+    ],
+    "name:zho_x_preferred":[
+        "\u65af\u5854\u97e6\u5229"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421175989,
-    "wof:lastmodified":1566583494,
+    "wof:lastmodified":1690875522,
     "wof:name":"Staoueli",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/175/991/421175991.geojson
+++ b/data/421/175/991/421175991.geojson
@@ -26,14 +26,29 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u0628\u0627\u062a\u0646\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u062a\u0646\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Batna"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0627\u062a\u0646\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Batna"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u0430\u0442\u043d\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u0411\u0430\u0442\u043d\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u099f\u09a8\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09ac\u09be\u09a4\u09a8\u09be"
     ],
     "name:bul_x_preferred":[
         "\u0411\u0430\u0442\u043d\u0430"
@@ -86,6 +101,9 @@
     "name:fra_x_preferred":[
         "Batna"
     ],
+    "name:frr_x_preferred":[
+        "Batna"
+    ],
     "name:glg_x_preferred":[
         "Batna"
     ],
@@ -97,6 +115,9 @@
     ],
     "name:hin_x_preferred":[
         "\u092c\u093e\u091f\u0928\u093e"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u0561\u0569\u0576\u0561"
     ],
     "name:ind_x_preferred":[
         "Batnah"
@@ -125,6 +146,9 @@
     "name:lad_x_preferred":[
         "Wilaya de Batna"
     ],
+    "name:lat_x_preferred":[
+        "Lambaesis"
+    ],
     "name:lav_x_preferred":[
         "B\u0101tina"
     ],
@@ -152,6 +176,9 @@
     "name:nor_x_preferred":[
         "Batna"
     ],
+    "name:oss_x_preferred":[
+        "\u0411\u0430\u0442\u043d\u00e6"
+    ],
     "name:pnb_x_preferred":[
         "\u0628\u0627\u062a\u0646\u06c1"
     ],
@@ -167,6 +194,9 @@
     "name:rus_x_preferred":[
         "\u0411\u0430\u0442\u043d\u0430"
     ],
+    "name:shy_x_preferred":[
+        "\u2d5c\u2d31\u2d30\u2d5f\u2d5d\u2d3b\u2d4f\u2d5c"
+    ],
     "name:sin_x_preferred":[
         "\u0db6\u0da7\u0dca\u0db1\u0dcf"
     ],
@@ -177,6 +207,9 @@
         "Batna"
     ],
     "name:sqi_x_preferred":[
+        "Batna"
+    ],
+    "name:swa_x_preferred":[
         "Batna"
     ],
     "name:swe_x_preferred":[
@@ -193,6 +226,9 @@
     ],
     "name:tur_x_preferred":[
         "Batna"
+    ],
+    "name:tzm_x_preferred":[
+        "\u2d31\u2d30\u2d5c\u2d4f\u2d30"
     ],
     "name:ukr_x_preferred":[
         "\u0411\u0430\u0442\u043d\u0430"
@@ -214,6 +250,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u7279\u7eb3"
+    ],
+    "name:zul_x_preferred":[
+        "Batna"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -352,7 +391,7 @@
         }
     ],
     "wof:id":421175991,
-    "wof:lastmodified":1566583494,
+    "wof:lastmodified":1690875521,
     "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0628\u0627\u062a\u0646\u0629",
     "wof:parent_id":85670851,
     "wof:placetype":"locality",

--- a/data/421/176/617/421176617.geojson
+++ b/data/421/176/617/421176617.geojson
@@ -23,6 +23,9 @@
     "name:arq_x_preferred":[
         "\u0627\u0644\u0639\u0644\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u0644\u0645\u0647"
+    ],
     "name:ben_x_preferred":[
         "\u098f\u09b2 \u098f\u0989\u09b2\u09cd\u09ae\u09be"
     ],
@@ -30,6 +33,9 @@
         "El Eulma"
     ],
     "name:dan_x_preferred":[
+        "El Eulma"
+    ],
+    "name:deu_x_preferred":[
         "El Eulma"
     ],
     "name:ell_x_preferred":[
@@ -95,6 +101,9 @@
     "name:por_x_preferred":[
         "El Eulma"
     ],
+    "name:pus_x_preferred":[
+        "\u0627\u0644\u0639\u0644\u0645\u0647"
+    ],
     "name:ron_x_preferred":[
         "El Eulma"
     ],
@@ -105,6 +114,9 @@
         "\u0d91\u0dbd\u0dca \u0d91\u0d8b\u0dbd\u0dca\u0db8\u0dcf"
     ],
     "name:spa_x_preferred":[
+        "El Eulma"
+    ],
+    "name:swa_x_preferred":[
         "El Eulma"
     ],
     "name:swe_x_preferred":[
@@ -189,7 +201,7 @@
         }
     ],
     "wof:id":421176617,
-    "wof:lastmodified":1566583504,
+    "wof:lastmodified":1690875536,
     "wof:name":"El Eulma",
     "wof:parent_id":85670845,
     "wof:placetype":"locality",

--- a/data/421/177/627/421177627.geojson
+++ b/data/421/177/627/421177627.geojson
@@ -20,8 +20,20 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u0628\u064a\u0636\u0627\u0621"
     ],
+    "name:ary_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0628\u064a\u0636\u0627\u0621"
+    ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0628\u064a\u0636\u0627\u0621"
+    ],
+    "name:ast_x_preferred":[
+        "A\u00efn Be\u00efda"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0627\u0644\u0628\u06cc\u0636\u0627\u0621"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fyn-B\u0259yda"
     ],
     "name:ben_x_preferred":[
         "\u0986\u0987\u09a8 \u09ac\u09c7\u0987\u09a1\u09be"
@@ -32,8 +44,14 @@
     "name:dan_x_preferred":[
         "A\u00efn Be\u00efda"
     ],
+    "name:deu_x_preferred":[
+        "Ain Beida"
+    ],
     "name:ell_x_preferred":[
         "\u0391\u03b9\u03bd \u039c\u03c0\u03b5\u0390\u03bd\u03c4\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0391\u0390\u03bd \u039c\u03c0\u03b5\u03ca\u03bd\u03c4\u03ac"
     ],
     "name:eng_x_preferred":[
         "A\u00efn Be\u00efda"
@@ -52,6 +70,9 @@
     ],
     "name:fra_x_preferred":[
         "A\u00efn B\u00e9\u00efda"
+    ],
+    "name:fra_x_variant":[
+        "A\u00efn Be\u00efda"
     ],
     "name:guj_x_preferred":[
         "\u0a8f\u0aa8 \u0aac\u0ac7\u0a88\u0aa1\u0abe"
@@ -122,11 +143,17 @@
     "name:spa_x_preferred":[
         "Ain Beida"
     ],
+    "name:swa_x_preferred":[
+        "A\u00efn Be\u00efda"
+    ],
     "name:swe_x_preferred":[
         "A\u00efn B\u00e9\u00efda"
     ],
     "name:tam_x_preferred":[
         "\u0b86\u0baf\u0bbf\u0ba9\u0bcd \u0baa\u0bc6\u0baf\u0bcd\u0b9f\u0bbe"
+    ],
+    "name:tam_x_variant":[
+        "\u0b86\u0baf\u0bbf\u0ba9\u0bcd \u0baa\u0bc6\u0baf\u0bcd\u0b9f\u0bbe "
     ],
     "name:tel_x_preferred":[
         "\u0c10\u0c28\u0c4d \u0c2c\u0c40\u0c21\u0c3e"
@@ -147,7 +174,8 @@
         "\u0627\u00ef\u0646 \u0628\u06cc\u00ef\u062f\u0627 \u060c \u0648\u0648\u0645 \u0627\u0644 \u0628\u0648\u0648\u0627\u06af\u06be\u06cc"
     ],
     "name:urd_x_variant":[
-        "\u0627\u00ef\u0646 \u0628\u06cc\u00ef\u062f\u0627"
+        "\u0627\u00ef\u0646 \u0628\u06cc\u00ef\u062f\u0627",
+        "\u0627\u00ef\u0646 \u0628\u06cc\u00ef\u062f\u0627 "
     ],
     "name:vie_x_preferred":[
         "Ain Beida"
@@ -157,6 +185,9 @@
     ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u8d1d\u8fbe"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Be\u00efda"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -204,7 +235,7 @@
         }
     ],
     "wof:id":421177627,
-    "wof:lastmodified":1587163137,
+    "wof:lastmodified":1690875531,
     "wof:name":"Ain Beida",
     "wof:parent_id":85670871,
     "wof:placetype":"locality",

--- a/data/421/177/877/421177877.geojson
+++ b/data/421/177/877/421177877.geojson
@@ -59,6 +59,9 @@
     "name:und_x_variant":[
         "Souk et Tnine"
     ],
+    "name:uzb_x_preferred":[
+        "Souk El-Tenin"
+    ],
     "name:vie_x_preferred":[
         "Souk El Tenine"
     ],
@@ -67,6 +70,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8607\u683c\u585e\u5be7"
+    ],
+    "name:zul_x_preferred":[
+        "Souk El-Thenine"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -113,7 +119,7 @@
         }
     ],
     "wof:id":421177877,
-    "wof:lastmodified":1566583500,
+    "wof:lastmodified":1690875531,
     "wof:name":"Souk et Tenine",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/178/107/421178107.geojson
+++ b/data/421/178/107/421178107.geojson
@@ -19,6 +19,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u062c\u064a\u0646 \u0623\u062a\u064a\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u062c\u064a\u0646 \u0627\u062a\u064a\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "Eug\u00e8ne \u00c9tienne"
     ],
@@ -37,6 +40,9 @@
     "name:fas_x_preferred":[
         "\u0627\u0648\u0698\u0646 \u0627\u062a\u06cc\u0646"
     ],
+    "name:fin_x_preferred":[
+        "Eug\u00e8ne \u00c9tienne"
+    ],
     "name:fra_x_preferred":[
         "Eug\u00e8ne \u00c9tienne"
     ],
@@ -48,6 +54,9 @@
     ],
     "name:ita_x_preferred":[
         "Eug\u00e8ne \u00c9tienne"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a6\u30b8\u30a7\u30fc\u30cc\u30fb\u30a8\u30c6\u30a3\u30a8\u30f3\u30cc"
     ],
     "name:lat_x_preferred":[
         "Eugenius \u00c9tienne"
@@ -73,7 +82,13 @@
     "name:nob_x_preferred":[
         "Eug\u00e8ne \u00c9tienne"
     ],
+    "name:pap_x_preferred":[
+        "Eug\u00e8ne \u00c9tienne"
+    ],
     "name:pol_x_preferred":[
+        "Eug\u00e8ne \u00c9tienne"
+    ],
+    "name:por_x_preferred":[
         "Eug\u00e8ne \u00c9tienne"
     ],
     "name:rus_x_preferred":[
@@ -90,6 +105,9 @@
     ],
     "name:und_x_variant":[
         "\u00c9tienne"
+    ],
+    "name:zho_x_preferred":[
+        "\u5c24\u91d1\u00b7\u827e\u8482\u5b89"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPLX",
@@ -136,7 +154,7 @@
         }
     ],
     "wof:id":421178107,
-    "wof:lastmodified":1566583502,
+    "wof:lastmodified":1690875534,
     "wof:name":"Eug\u00e8ne \u00c9tienne",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/178/261/421178261.geojson
+++ b/data/421/178/261/421178261.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u0644\u0627\u0645\u0628\u0627\u064a\u0632\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u0645\u0628\u0627\u064a\u0632\u064a\u0633"
+    ],
     "name:cat_x_preferred":[
         "Lambaesis"
     ],
@@ -50,6 +53,9 @@
     "name:nld_x_preferred":[
         "Castra Lambaesis"
     ],
+    "name:nob_x_preferred":[
+        "Lamb\u00e8se"
+    ],
     "name:pol_x_preferred":[
         "Lambesis"
     ],
@@ -60,6 +66,9 @@
         "\u041b\u0430\u043c\u0431\u0435\u0437\u0438\u0441"
     ],
     "name:spa_x_preferred":[
+        "Lambaesis"
+    ],
+    "name:swa_x_preferred":[
         "Lambaesis"
     ],
     "name:swe_x_preferred":[
@@ -119,7 +128,7 @@
         }
     ],
     "wof:id":421178261,
-    "wof:lastmodified":1566583501,
+    "wof:lastmodified":1690875533,
     "wof:name":"Tazoult-lambese",
     "wof:parent_id":85670851,
     "wof:placetype":"locality",

--- a/data/421/178/263/421178263.geojson
+++ b/data/421/178/263/421178263.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u062f\u064a\u0629 \u0627\u0644\u0631\u063a\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u063a\u0627\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u063a\u0627\u06cc\u0647"
     ],
@@ -56,11 +59,20 @@
     "name:ron_x_preferred":[
         "Regha\u00efa"
     ],
+    "name:rus_x_preferred":[
+        "\u0420\u0435\u0433\u0430\u044f"
+    ],
     "name:spa_x_preferred":[
         "Regha\u00efa"
     ],
     "name:swe_x_preferred":[
         "Regha\u00efa"
+    ],
+    "name:tur_x_preferred":[
+        "Ri\u011faya"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0420\u0435\u0433\u0430\u044f"
     ],
     "name:und_x_variant":[
         "La Reghia-Alma"
@@ -117,7 +129,7 @@
         }
     ],
     "wof:id":421178263,
-    "wof:lastmodified":1566583502,
+    "wof:lastmodified":1690875535,
     "wof:name":"Reghaia",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/178/269/421178269.geojson
+++ b/data/421/178/269/421178269.geojson
@@ -20,10 +20,19 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0635\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0642\u0635\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0635\u0631"
     ],
+    "name:cat_x_preferred":[
+        "El Kseur"
+    ],
     "name:ceb_x_preferred":[
+        "El Kseur"
+    ],
+    "name:deu_x_preferred":[
         "El Kseur"
     ],
     "name:eng_x_preferred":[
@@ -53,6 +62,9 @@
     "name:nld_x_preferred":[
         "El-Kseur"
     ],
+    "name:pol_x_preferred":[
+        "El Kseur"
+    ],
     "name:por_x_preferred":[
         "El-Kseur"
     ],
@@ -61,6 +73,9 @@
     ],
     "name:spa_x_preferred":[
         "El Kseur"
+    ],
+    "name:swa_x_preferred":[
+        "El-Kseur"
     ],
     "name:swe_x_preferred":[
         "El Kseur"
@@ -73,6 +88,9 @@
     ],
     "name:zho_x_preferred":[
         "\u514b\u745f"
+    ],
+    "name:zul_x_preferred":[
+        "El Kseur"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -120,7 +138,7 @@
         }
     ],
     "wof:id":421178269,
-    "wof:lastmodified":1566583502,
+    "wof:lastmodified":1690875534,
     "wof:name":"El Kseur",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/178/271/421178271.geojson
+++ b/data/421/178/271/421178271.geojson
@@ -23,11 +23,17 @@
     "name:arq_x_preferred":[
         "\u0627\u0644\u062e\u0631\u0648\u0628"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062e\u0631\u0648\u0628"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u062e\u0631\u0648\u0628"
     ],
     "name:ceb_x_preferred":[
         "El Khroub"
+    ],
+    "name:deu_x_preferred":[
+        "El Chroub"
     ],
     "name:eng_x_preferred":[
         "El Khroub"
@@ -65,11 +71,17 @@
     "name:nld_x_preferred":[
         "El Khroub"
     ],
+    "name:nob_x_preferred":[
+        "El Khroub"
+    ],
     "name:pol_x_preferred":[
         "Al-Churub"
     ],
     "name:por_x_preferred":[
         "El Khroub"
+    ],
+    "name:pus_x_preferred":[
+        "\u0627\u0644\u062e\u0631\u0648\u0628"
     ],
     "name:ron_x_preferred":[
         "El-Khroub"
@@ -79,6 +91,9 @@
     ],
     "name:spa_x_preferred":[
         "El Khroub"
+    ],
+    "name:swa_x_preferred":[
+        "El-Khroub"
     ],
     "name:swe_x_preferred":[
         "El-Khroub"
@@ -147,7 +162,7 @@
         }
     ],
     "wof:id":421178271,
-    "wof:lastmodified":1566583502,
+    "wof:lastmodified":1690875534,
     "wof:name":"Le Khroub",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",

--- a/data/421/178/273/421178273.geojson
+++ b/data/421/178/273/421178273.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0634\u0645\u064a\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0645\u064a\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0645\u06cc\u0646\u06cc"
     ],
@@ -50,6 +53,9 @@
     "name:nld_x_preferred":[
         "Chemini"
     ],
+    "name:pol_x_preferred":[
+        "Chemini"
+    ],
     "name:por_x_preferred":[
         "Chemini"
     ],
@@ -65,6 +71,9 @@
     "name:und_x_variant":[
         "Azrou-n-A\u00eft Chemini"
     ],
+    "name:uzb_x_preferred":[
+        "Chemini"
+    ],
     "name:vie_x_preferred":[
         "Chemini"
     ],
@@ -73,6 +82,9 @@
     ],
     "name:zho_x_preferred":[
         "\u820d\u7c73\u5c3c"
+    ],
+    "name:zul_x_preferred":[
+        "Chemini"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -120,7 +132,7 @@
         }
     ],
     "wof:id":421178273,
-    "wof:lastmodified":1566583501,
+    "wof:lastmodified":1690875532,
     "wof:name":"Chemini",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/178/275/421178275.geojson
+++ b/data/421/178/275/421178275.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u0635\u0641\u0631\u0627\u0621"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0635\u0641\u0631\u0627\u0621"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0635\u0641\u0631\u0627\u0621"
     ],
@@ -50,6 +53,9 @@
     "name:fry_x_preferred":[
         "A\u00efn Sefra"
     ],
+    "name:heb_x_preferred":[
+        "\u05e2\u05d9\u05df \u05e1\u05e4\u05e8\u05d4"
+    ],
     "name:ind_x_preferred":[
         "A\u00efn S\u00e9fra"
     ],
@@ -58,6 +64,9 @@
     ],
     "name:kab_x_preferred":[
         "Ti\u1e6d Tawra\u0263t"
+    ],
+    "name:kab_x_variant":[
+        "\u0190in \u1e62\u1e63efra"
     ],
     "name:lit_x_preferred":[
         "Ain Sefra"
@@ -82,6 +91,9 @@
     ],
     "name:spa_x_preferred":[
         "A\u00efn S\u00e9fra"
+    ],
+    "name:swa_x_preferred":[
+        "A\u00efn Sefra"
     ],
     "name:swe_x_preferred":[
         "A\u00efn Sefra"
@@ -230,7 +242,7 @@
         }
     ],
     "wof:id":421178275,
-    "wof:lastmodified":1566583501,
+    "wof:lastmodified":1690875533,
     "wof:name":"Ain Sefra",
     "wof:parent_id":85670707,
     "wof:placetype":"locality",

--- a/data/421/178/857/421178857.geojson
+++ b/data/421/178/857/421178857.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0635\u0627\u0644\u062d \u0628\u0627\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0635\u0627\u0644\u062d \u0628\u0627\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0635\u0627\u0644\u062d \u0628\u0627\u06cc"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Salah Bey"
+    ],
+    "name:kab_x_preferred":[
+        "Sale\u1e25 Bay"
     ],
     "name:msa_x_preferred":[
         "Salah Bey"
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":421178857,
-    "wof:lastmodified":1566583501,
+    "wof:lastmodified":1690875533,
     "wof:name":"Salah Bey",
     "wof:parent_id":85670845,
     "wof:placetype":"locality",

--- a/data/421/178/861/421178861.geojson
+++ b/data/421/178/861/421178861.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0627\u062f\u064a \u0627\u0631\u0647\u064a\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0648\u0627\u062f\u0649 \u0627\u0631\u0647\u064a\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f\u06cc \u0627\u0631\u0647\u06cc\u0648"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:und_x_variant":[
         "Inkermann"
+    ],
+    "name:uzb_x_preferred":[
+        "Oued Rhiou"
     ],
     "name:vie_x_preferred":[
         "Oued Rhiou"
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":421178861,
-    "wof:lastmodified":1566583501,
+    "wof:lastmodified":1690875533,
     "wof:name":"Oued Rhiou",
     "wof:parent_id":85670791,
     "wof:placetype":"locality",

--- a/data/421/178/863/421178863.geojson
+++ b/data/421/178/863/421178863.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0627\u062f\u064a \u0627\u0644\u0641\u0636\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0648\u0627\u062f\u0649 \u0627\u0644\u0641\u0636\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f\u06cc \u0641\u0636\u0647"
     ],
@@ -38,11 +41,17 @@
     "name:fra_x_preferred":[
         "Oued Fodda"
     ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05dc\u05d2'\u05d9\u05e8\u05d9\u05d4"
+    ],
     "name:ita_x_preferred":[
         "Oued Fodda"
     ],
     "name:kab_x_preferred":[
         "Wad Fe\u1e0d\u1e0da"
+    ],
+    "name:kab_x_variant":[
+        "Wad Lfe\u1e0d\u1e0da"
     ],
     "name:msa_x_preferred":[
         "Oued Fodda"
@@ -73,6 +82,9 @@
     ],
     "name:zho_x_preferred":[
         "\u74e6\u8fea\u5bcc\u9054"
+    ],
+    "name:zul_x_preferred":[
+        "Oued Fodda"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -120,7 +132,7 @@
         }
     ],
     "wof:id":421178863,
-    "wof:lastmodified":1566583502,
+    "wof:lastmodified":1690875535,
     "wof:name":"Oued Fodda",
     "wof:parent_id":85670781,
     "wof:placetype":"locality",

--- a/data/421/178/865/421178865.geojson
+++ b/data/421/178/865/421178865.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0645\u0631\u0648\u0627\u0646\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0631\u0648\u0627\u0646\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0631\u0648\u0627\u0646\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "M\u0259ruana"
     ],
     "name:ceb_x_preferred":[
         "Merouana"
@@ -59,6 +65,9 @@
     "name:nld_x_preferred":[
         "Merouana"
     ],
+    "name:pol_x_preferred":[
+        "Merouana"
+    ],
     "name:por_x_preferred":[
         "Merouana"
     ],
@@ -88,6 +97,12 @@
     ],
     "name:zho_x_preferred":[
         "\u5452\u67d3\u6316\u554a\u55ef\u554a"
+    ],
+    "name:zho_x_variant":[
+        "\u8fc8\u5c14\u74e6\u7eb3"
+    ],
+    "name:zul_x_preferred":[
+        "Merouana"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -135,7 +150,7 @@
         }
     ],
     "wof:id":421178865,
-    "wof:lastmodified":1566583502,
+    "wof:lastmodified":1690875534,
     "wof:name":"Merouana",
     "wof:parent_id":85670851,
     "wof:placetype":"locality",

--- a/data/421/178/867/421178867.geojson
+++ b/data/421/178/867/421178867.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0631\u064a\u062d\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0631\u064a\u062d\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0641\u0631\u06cc\u062d\u0647"
     ],
@@ -65,6 +68,9 @@
     "name:und_x_variant":[
         "Freda"
     ],
+    "name:uzb_x_preferred":[
+        "Freha"
+    ],
     "name:vie_x_preferred":[
         "Freha"
     ],
@@ -73,6 +79,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5f17\u96f7\u54c8"
+    ],
+    "name:zul_x_preferred":[
+        "Freha"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421178867,
-    "wof:lastmodified":1566583502,
+    "wof:lastmodified":1690875534,
     "wof:name":"Freha",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/178/869/421178869.geojson
+++ b/data/421/178/869/421178869.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0639\u0628\u0627\u062f\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u0628\u0627\u062f\u064a\u0647"
+    ],
     "name:ceb_x_preferred":[
         "El Abadia"
     ],
@@ -45,6 +48,9 @@
         "El Abadia"
     ],
     "name:nld_x_preferred":[
+        "El Abadia"
+    ],
+    "name:pol_x_preferred":[
         "El Abadia"
     ],
     "name:por_x_preferred":[
@@ -117,7 +123,7 @@
         }
     ],
     "wof:id":421178869,
-    "wof:lastmodified":1566583502,
+    "wof:lastmodified":1690875533,
     "wof:name":"El Abadia",
     "wof:parent_id":85670777,
     "wof:placetype":"locality",

--- a/data/421/178/875/421178875.geojson
+++ b/data/421/178/875/421178875.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0648\u0633\u0627\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0648\u0633\u0627\u0631\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0648\u0633\u0627\u0631\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fyn-\u00dcs\u0259ra"
     ],
     "name:ben_x_preferred":[
         "\u0986\u0987\u09a8 \u0993\u09b8\u09c7\u09b0\u09be"
@@ -32,8 +38,14 @@
     "name:dan_x_preferred":[
         "A\u00efn Oussera"
     ],
+    "name:deu_x_preferred":[
+        "Ain Oussera"
+    ],
     "name:ell_x_preferred":[
         "\u0386\u03b9\u03bd \u039f\u03c5\u03c3\u03c3\u03b5\u03c1\u03ac"
+    ],
+    "name:ell_x_variant":[
+        "\u0386\u03b9\u03bd \u039f\u03c5\u03c3\u03b5\u03c1\u03ac"
     ],
     "name:eng_x_preferred":[
         "A\u00efn Oussera"
@@ -111,6 +123,9 @@
         "\u0d85\u0dba\u0dd2\u0db1\u0dca \u0d94\u0d8b\u0dc3\u0dda\u0dbb\u0dcf"
     ],
     "name:spa_x_preferred":[
+        "A\u00efn Oussara"
+    ],
+    "name:swa_x_preferred":[
         "A\u00efn Oussara"
     ],
     "name:swe_x_preferred":[
@@ -192,7 +207,7 @@
         }
     ],
     "wof:id":421178875,
-    "wof:lastmodified":1566583501,
+    "wof:lastmodified":1690875532,
     "wof:name":"Ain Oussera",
     "wof:parent_id":85670833,
     "wof:placetype":"locality",

--- a/data/421/180/069/421180069.geojson
+++ b/data/421/180/069/421180069.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0645\u0627\u0644\u0648\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0645\u0627\u0644\u0648\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0645\u0627\u0644\u0648\u0633"
     ],
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421180069,
-    "wof:lastmodified":1566583490,
+    "wof:lastmodified":1690875518,
     "wof:name":"Tamalous",
     "wof:parent_id":85670727,
     "wof:placetype":"locality",

--- a/data/421/180/073/421180073.geojson
+++ b/data/421/180/073/421180073.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062e\u0645\u064a\u0633 \u0645\u0644\u064a\u0627\u0646\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062e\u0645\u064a\u0633 \u0645\u0644\u064a\u0627\u0646\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062e\u0645\u06cc\u0633 \u0645\u0644\u06cc\u0627\u0646\u0647"
     ],
@@ -69,6 +72,9 @@
         "Khemis Miliana"
     ],
     "name:spa_x_preferred":[
+        "Khemis Miliana"
+    ],
+    "name:swa_x_preferred":[
         "Khemis Miliana"
     ],
     "name:swe_x_preferred":[
@@ -132,7 +138,7 @@
         }
     ],
     "wof:id":421180073,
-    "wof:lastmodified":1566583490,
+    "wof:lastmodified":1690875518,
     "wof:name":"Khemis Miliana",
     "wof:parent_id":85670777,
     "wof:placetype":"locality",

--- a/data/421/180/345/421180345.geojson
+++ b/data/421/180/345/421180345.geojson
@@ -20,8 +20,20 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0645\u0631\u062f\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0645\u0631\u062f\u0627\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Boumerd\u00e8s"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u0645\u0631\u062f\u0627\u0633"
+    ],
+    "name:aze_x_preferred":[
+        "Bumerdes"
+    ],
+    "name:cat_x_preferred":[
+        "Boumerdes"
     ],
     "name:ceb_x_preferred":[
         "Boumerdas"
@@ -29,11 +41,17 @@
     "name:deu_x_preferred":[
         "Boumerd\u00e8s"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03c5\u03bc\u03b5\u03c1\u03bd\u03c4\u03ad\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Boumerd\u00e8s"
     ],
     "name:fas_x_preferred":[
         "\u0628\u0648\u0645\u0631\u062f\u0627\u0633"
+    ],
+    "name:fin_x_preferred":[
+        "Boumerd\u00e8s"
     ],
     "name:fra_x_preferred":[
         "Boumerd\u00e8s"
@@ -43,6 +61,9 @@
     ],
     "name:ita_x_preferred":[
         "Boumerd\u00e8s"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d6\u30e1\u30eb\u30c7\u30b9"
     ],
     "name:kab_x_preferred":[
         "Bumerdas"
@@ -143,7 +164,7 @@
         }
     ],
     "wof:id":421180345,
-    "wof:lastmodified":1566583490,
+    "wof:lastmodified":1690875518,
     "wof:name":"Cite de Boumerdes",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/180/373/421180373.geojson
+++ b/data/421/180/373/421180373.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a \u0645\u0633\u062a\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u0649 \u0645\u0633\u062a\u0627\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc \u0645\u0633\u062a\u0627\u0631"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:ita_x_preferred":[
         "Beni Mester"
+    ],
+    "name:kab_x_preferred":[
+        "Bni Mestar"
     ],
     "name:msa_x_preferred":[
         "Beni Mester"
@@ -68,10 +74,16 @@
     "name:swe_x_preferred":[
         "Beni Mester"
     ],
+    "name:uzb_x_preferred":[
+        "Beni Mester"
+    ],
     "name:vie_x_preferred":[
         "Beni Mester"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Beni Mester"
+    ],
+    "name:zul_x_preferred":[
         "Beni Mester"
     ],
     "qs:gn_country":"DZ",
@@ -120,7 +132,7 @@
         }
     ],
     "wof:id":421180373,
-    "wof:lastmodified":1566583490,
+    "wof:lastmodified":1690875519,
     "wof:name":"Beni Mester",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/421/180/377/421180377.geojson
+++ b/data/421/180/377/421180377.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0627\u062f\u064a \u0633\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0648\u0627\u062f\u0649 \u0633\u0644\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f\u06cc \u0633\u0644\u06cc"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Oued Sly"
+    ],
+    "name:kab_x_preferred":[
+        "Wad Sli"
     ],
     "name:msa_x_preferred":[
         "Oued Sly"
@@ -69,6 +75,9 @@
         "Oued Sly"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Oued Sly"
+    ],
+    "name:zul_x_preferred":[
         "Oued Sly"
     ],
     "qs:gn_country":"DZ",
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":421180377,
-    "wof:lastmodified":1566583490,
+    "wof:lastmodified":1690875518,
     "wof:name":"Oued Sly",
     "wof:parent_id":85670781,
     "wof:placetype":"locality",

--- a/data/421/180/379/421180379.geojson
+++ b/data/421/180/379/421180379.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u0645\u0631\u0648\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0645\u0631\u0648\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0645\u0631\u0648\u0627\u0646"
     ],
@@ -35,8 +38,14 @@
     "name:fra_x_preferred":[
         "Sidi M\u00e9rouane"
     ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d9\u05d3\u05d9 \u05de\u05e8\u05d5\u05d5\u05d0\u05df"
+    ],
     "name:ita_x_preferred":[
         "Sidi M\u00e9rouane"
+    ],
+    "name:kab_x_preferred":[
+        "Sidi Merwan"
     ],
     "name:msa_x_preferred":[
         "Sidi Merouane"
@@ -64,6 +73,9 @@
     ],
     "name:vie_x_preferred":[
         "Sidi Merouane"
+    ],
+    "name:zho_x_preferred":[
+        "\u897f\u8fea\u6885\u9c81\u5b89"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421180379,
-    "wof:lastmodified":1566583490,
+    "wof:lastmodified":1690875517,
     "wof:name":"Sidi Merouane",
     "wof:parent_id":85670867,
     "wof:placetype":"locality",

--- a/data/421/181/849/421181849.geojson
+++ b/data/421/181/849/421181849.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_variant":[
         "\u0628\u0644\u062f\u064a\u0629 \u0627\u0644\u0645\u062f\u0646\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u062f\u0646\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u062f\u0646\u06cc\u0647"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:ita_x_preferred":[
         "El Madania"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a8\u30eb\u30fb\u30de\u30c0\u30cb\u30a2"
     ],
     "name:kab_x_preferred":[
         "Lmadaneyya"
@@ -57,6 +63,9 @@
     ],
     "name:spa_x_preferred":[
         "El Madania"
+    ],
+    "name:tur_x_preferred":[
+        "El-Medeniye"
     ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u0645\u062f\u06cc\u0646\u06c1\u060c \u0627\u0644\u062c\u0632\u0627\u0626\u0631"
@@ -116,7 +125,7 @@
         }
     ],
     "wof:id":421181849,
-    "wof:lastmodified":1566583493,
+    "wof:lastmodified":1690875521,
     "wof:name":"El Madania",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/182/055/421182055.geojson
+++ b/data/421/182/055/421182055.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0623\u0631\u0646\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0631\u0646\u0627\u062a"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0627\u0631\u0646\u0627\u062a"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:nld_x_preferred":[
         "A\u00efn Arnat"
+    ],
+    "name:pol_x_preferred":[
+        "Ajn Arnat"
     ],
     "name:por_x_preferred":[
         "A\u00efn Arnat"
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":421182055,
-    "wof:lastmodified":1566583503,
+    "wof:lastmodified":1690875536,
     "wof:name":"'Ain Arnat",
     "wof:parent_id":85670845,
     "wof:placetype":"locality",

--- a/data/421/182/383/421182383.geojson
+++ b/data/421/182/383/421182383.geojson
@@ -19,8 +19,14 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u0631 \u0645\u0631\u0627\u062f \u0631\u0627\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u0631 \u0645\u0631\u0627\u062f \u0631\u0627\u064a\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u06cc\u0631 \u0645\u0631\u0627\u062f \u0631\u0627\u06cc\u0633"
+    ],
+    "name:aze_x_preferred":[
+        "Bir-Murad-Rays"
     ],
     "name:cym_x_preferred":[
         "Bir Mourad Ra\u00efs"
@@ -28,14 +34,23 @@
     "name:dan_x_preferred":[
         "Bir Mourad Ra\u00efs"
     ],
+    "name:deu_x_preferred":[
+        "Birmandreis"
+    ],
     "name:eng_x_preferred":[
         "Bir Mourad Ra\u00efs"
+    ],
+    "name:eng_x_variant":[
+        "Bir Mourad Rais"
     ],
     "name:fas_x_preferred":[
         "\u0628\u06cc\u0631 \u0645\u0631\u0627\u062f \u0631\u0627\u06cc\u0633"
     ],
     "name:fra_x_preferred":[
         "Bir Mourad Ra\u00efs"
+    ],
+    "name:gle_x_preferred":[
+        "Bir Mourad Rais"
     ],
     "name:hrv_x_preferred":[
         "Bir Mourad Ra\u00efs"
@@ -58,6 +73,9 @@
     "name:nld_x_preferred":[
         "Bir Mourad Ra\u00efs"
     ],
+    "name:pol_x_preferred":[
+        "Bir Mourad Ra\u00efs"
+    ],
     "name:por_x_preferred":[
         "Bir Mourad Ra\u00efs"
     ],
@@ -70,6 +88,12 @@
     "name:spa_x_preferred":[
         "Bir Mourad Ra\u00efs"
     ],
+    "name:swe_x_preferred":[
+        "Bir Mourad Ra\u00efs"
+    ],
+    "name:tur_x_preferred":[
+        "Bir Murad Reis"
+    ],
     "name:und_x_variant":[
         "Le Redoute"
     ],
@@ -78,6 +102,9 @@
     ],
     "name:vie_x_preferred":[
         "Bir Mourad Rais"
+    ],
+    "name:zho_x_preferred":[
+        "\u6bd4\u66fc\u5fb7\u5229"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPLX",
@@ -124,7 +151,7 @@
         }
     ],
     "wof:id":421182383,
-    "wof:lastmodified":1566583503,
+    "wof:lastmodified":1690875536,
     "wof:name":"Bir Mourad Rais",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/182/417/421182417.geojson
+++ b/data/421/182/417/421182417.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0623\u0632\u0641\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0632\u0641\u0648\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0632\u0641\u0648\u0646"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03b6\u03b5\u03c6\u03bf\u03cd\u03bd"
     ],
     "name:eng_x_preferred":[
         "Azeffoun"
@@ -56,6 +62,9 @@
     "name:spa_x_preferred":[
         "Azeffoun"
     ],
+    "name:swa_x_preferred":[
+        "Azeffoun"
+    ],
     "name:und_x_variant":[
         "Port Guedon"
     ],
@@ -67,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u5bb0\u8c50"
+    ],
+    "name:zul_x_preferred":[
+        "Azeffoun"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -113,7 +125,7 @@
         }
     ],
     "wof:id":421182417,
-    "wof:lastmodified":1566583503,
+    "wof:lastmodified":1690875536,
     "wof:name":"Azeffoun",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/182/753/421182753.geojson
+++ b/data/421/182/753/421182753.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0631\u0628\u0627\u062d\u060c\u0627\u0644\u0648\u0627\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u0628\u0627\u062d"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0628\u0627\u062d"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:ita_x_preferred":[
         "Robbah"
+    ],
+    "name:kab_x_preferred":[
+        "Rrebba\u1e25"
     ],
     "name:msa_x_preferred":[
         "Robbah"
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":421182753,
-    "wof:lastmodified":1566583503,
+    "wof:lastmodified":1690875535,
     "wof:name":"Robbah",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",

--- a/data/421/182/755/421182755.geojson
+++ b/data/421/182/755/421182755.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0642\u0644\u0639"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0642\u0644\u0639"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0642\u0644\u0639"
     ],
@@ -65,6 +68,9 @@
     "name:swe_x_preferred":[
         "Mekla"
     ],
+    "name:uzb_x_preferred":[
+        "Mekla"
+    ],
     "name:vie_x_preferred":[
         "Mekla"
     ],
@@ -73,6 +79,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9081\u514b\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Mekla"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421182755,
-    "wof:lastmodified":1566583503,
+    "wof:lastmodified":1690875535,
     "wof:name":"Mekla",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/183/231/421183231.geojson
+++ b/data/421/183/231/421183231.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u063a\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u063a\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u063a\u0646\u06cc"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:fra_x_preferred":[
         "Boghni"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d5\u05d2\u05e0\u05d9"
     ],
     "name:ita_x_preferred":[
         "Boghni"
@@ -73,6 +79,9 @@
     ],
     "name:zho_x_preferred":[
         "\u535a\u683c\u5c3c"
+    ],
+    "name:zul_x_preferred":[
+        "Boghni"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421183231,
-    "wof:lastmodified":1566583501,
+    "wof:lastmodified":1690875532,
     "wof:name":"Boghni",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/185/101/421185101.geojson
+++ b/data/421/185/101/421185101.geojson
@@ -19,6 +19,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0637\u0645\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0645\u0648\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0637\u0645\u0648\u0631"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:ita_x_preferred":[
         "Matemore"
+    ],
+    "name:kab_x_preferred":[
+        "Me\u1e6dmur"
     ],
     "name:msa_x_preferred":[
         "Matemore"
@@ -54,6 +60,9 @@
     ],
     "name:und_x_variant":[
         "Matamore"
+    ],
+    "name:uzb_x_preferred":[
+        "Matemore"
     ],
     "name:vie_x_preferred":[
         "El Matmor"
@@ -103,7 +112,7 @@
         }
     ],
     "wof:id":421185101,
-    "wof:lastmodified":1566583505,
+    "wof:lastmodified":1690875538,
     "wof:name":"Matemore",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/619/421185619.geojson
+++ b/data/421/185/619/421185619.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0633\u062d\u0627\u0648\u0644\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0633\u062d\u0627\u0648\u0644\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u062d\u0627\u0648\u0644\u0647"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:swe_x_preferred":[
         "Saoula"
+    ],
+    "name:tur_x_preferred":[
+        "Sahavile"
     ],
     "name:urd_x_preferred":[
         "\u0633\u062d\u0627\u0648\u0644\u06c1"
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":421185619,
-    "wof:lastmodified":1566583505,
+    "wof:lastmodified":1690875537,
     "wof:name":"Saoula",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/185/621/421185621.geojson
+++ b/data/421/185/621/421185621.geojson
@@ -20,10 +20,22 @@
     "name:ara_x_preferred":[
         "\u0631\u0623\u0633 \u0627\u0644\u0648\u0627\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u0648\u0627\u062f\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0627\u0633 \u0648\u0627\u062f\u06cc"
     ],
+    "name:ceb_x_preferred":[
+        "R\u00e2s el Oued"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a1\u03b1\u03c2 \u0395\u03bb \u039f\u03c5\u03ad\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
+        "Ras El Oued"
+    ],
+    "name:eus_x_preferred":[
         "Ras El Oued"
     ],
     "name:fas_x_preferred":[
@@ -59,8 +71,14 @@
     "name:spa_x_preferred":[
         "Ras El Oued"
     ],
+    "name:swe_x_preferred":[
+        "R\u00e2s el Oued"
+    ],
     "name:und_x_variant":[
         "Tocqueville"
+    ],
+    "name:uzb_x_preferred":[
+        "Ras El Oud"
     ],
     "name:vie_x_preferred":[
         "Ras El Oued"
@@ -110,7 +128,7 @@
         }
     ],
     "wof:id":421185621,
-    "wof:lastmodified":1566583505,
+    "wof:lastmodified":1690875537,
     "wof:name":"Ras El Oued",
     "wof:parent_id":85670809,
     "wof:placetype":"locality",

--- a/data/421/185/623/421185623.geojson
+++ b/data/421/185/623/421185623.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0631\u0623\u0633 \u0627\u0644\u0639\u064a\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u0639\u064a\u0648\u0646"
+    ],
     "name:ceb_x_preferred":[
         "R\u00e2s el A\u00efoun"
     ],
@@ -47,6 +50,9 @@
     "name:nld_x_preferred":[
         "Ras El Aioun"
     ],
+    "name:pol_x_preferred":[
+        "Ras al-Ujun"
+    ],
     "name:por_x_preferred":[
         "Ras El Aioun"
     ],
@@ -59,10 +65,16 @@
     "name:und_x_variant":[
         "Rass el A\u00efoun"
     ],
+    "name:uzb_x_preferred":[
+        "Ras El Ayun"
+    ],
     "name:vie_x_preferred":[
         "Ras El Aioun"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Ras El Aioun"
+    ],
+    "name:zul_x_preferred":[
         "Ras El Aioun"
     ],
     "qs:gn_country":"DZ",
@@ -111,7 +123,7 @@
         }
     ],
     "wof:id":421185623,
-    "wof:lastmodified":1566583506,
+    "wof:lastmodified":1690875539,
     "wof:name":"Ras el Aioun",
     "wof:parent_id":85670851,
     "wof:placetype":"locality",

--- a/data/421/185/625/421185625.geojson
+++ b/data/421/185/625/421185625.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0627\u062f\u064a \u0627\u0644\u0639\u0644\u0627\u064a\u0642"
     ],
+    "name:arz_x_preferred":[
+        "\u0648\u0627\u062f\u0649 \u0627\u0644\u0639\u0644\u0627\u064a\u0642"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f\u06cc \u0639\u0644\u0627\u06cc\u0642"
     ],
@@ -74,6 +77,9 @@
     "name:zho_min_nan_x_preferred":[
         "Oued Alleug"
     ],
+    "name:zul_x_preferred":[
+        "Oued El Alleug"
+    ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2485633,
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":421185625,
-    "wof:lastmodified":1566583506,
+    "wof:lastmodified":1690875538,
     "wof:name":"Oued el Alleug",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/185/641/421185641.geojson
+++ b/data/421/185/641/421185641.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0623\u0631\u0628\u0639\u0627\u0621 \u0646\u0627\u064a\u062b \u0625\u064a\u0631\u0627\u062b\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0627\u0631\u0628\u0639\u0627\u0621 \u0646\u0627\u064a\u062b \u0627\u064a\u0631\u0627\u062b\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0631\u0628\u0639\u0627\u0621 \u0646\u0627\u06cc\u062b \u0627\u06cc\u0631\u0627\u062b\u0646"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:kab_x_preferred":[
         "Lareb\u025ba n At Yiraten"
+    ],
+    "name:kab_x_variant":[
+        "Lareb\u025ba Nat Yiraten"
     ],
     "name:msa_x_preferred":[
         "Larba Nait Irathen"
@@ -68,6 +74,9 @@
     "name:urd_x_preferred":[
         "\u0644\u0627\u0631\u0628\u0627 \u0646\u0627\u062a\u06be \u0627\u0631\u0627\u062a\u06be\u0646"
     ],
+    "name:uzb_x_preferred":[
+        "Larbaa Nath Irathen"
+    ],
     "name:vie_x_preferred":[
         "Larbaa-Nath-Irathen"
     ],
@@ -76,6 +85,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u723e\u5df4\u7d0d\u7279\u4f0a\u62c9\u68ee"
+    ],
+    "name:zul_x_preferred":[
+        "Larba\u00e2 Nath Irathen"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":421185641,
-    "wof:lastmodified":1566583506,
+    "wof:lastmodified":1690875539,
     "wof:name":"L'arbaa Nait Irathen",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/185/643/421185643.geojson
+++ b/data/421/185/643/421185643.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u064a\u0634\u064a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u064a\u0634\u064a\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u06cc\u0634\u06cc\u0631"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "El Achir"
+    ],
+    "name:kab_x_preferred":[
+        "Lyacir"
     ],
     "name:msa_x_preferred":[
         "El Achir"
@@ -57,6 +63,9 @@
         "El Achir"
     ],
     "name:swe_x_preferred":[
+        "El Achir"
+    ],
+    "name:uzb_x_preferred":[
         "El Achir"
     ],
     "name:vie_x_preferred":[
@@ -111,7 +120,7 @@
         }
     ],
     "wof:id":421185643,
-    "wof:lastmodified":1566583504,
+    "wof:lastmodified":1690875536,
     "wof:name":"El Achir",
     "wof:parent_id":85670809,
     "wof:placetype":"locality",

--- a/data/421/185/647/421185647.geojson
+++ b/data/421/185/647/421185647.geojson
@@ -20,10 +20,19 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0641\u0627\u0631\u064a\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0641\u0627\u0631\u064a\u0643"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u0641\u0627\u0631\u06cc\u06a9"
     ],
+    "name:aze_x_preferred":[
+        "Bufarik"
+    ],
     "name:bre_x_preferred":[
+        "Boufarik"
+    ],
+    "name:cat_x_preferred":[
         "Boufarik"
     ],
     "name:ceb_x_preferred":[
@@ -35,6 +44,9 @@
     "name:deu_x_preferred":[
         "Boufarik"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03c5\u03c6\u03b1\u03c1\u03af\u03ba"
+    ],
     "name:eng_x_preferred":[
         "Boufarik"
     ],
@@ -43,6 +55,9 @@
     ],
     "name:fra_x_preferred":[
         "Boufarik"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u0578\u0582\u0586\u0561\u0580\u056b\u056f"
     ],
     "name:ita_x_preferred":[
         "Boufarik"
@@ -80,6 +95,9 @@
     "name:spa_x_preferred":[
         "Boufarik"
     ],
+    "name:swa_x_preferred":[
+        "Boufarik"
+    ],
     "name:swe_x_preferred":[
         "Boufarik"
     ],
@@ -90,6 +108,9 @@
         "Boufarik"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Boufarik"
+    ],
+    "name:zul_x_preferred":[
         "Boufarik"
     ],
     "qs:gn_country":"DZ",
@@ -138,7 +159,7 @@
         }
     ],
     "wof:id":421185647,
-    "wof:lastmodified":1566583506,
+    "wof:lastmodified":1690875538,
     "wof:name":"Boufarik",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/185/649/421185649.geojson
+++ b/data/421/185/649/421185649.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a \u0635\u0627\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u0649 \u0635\u0627\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc \u0635\u0627\u0641"
+    ],
+    "name:aze_x_preferred":[
+        "B\u0259ni-Saf"
     ],
     "name:ber_x_preferred":[
         "\u2d31\u2d4f\u2d49 \u2d59\u2d30\u2d3c"
@@ -41,8 +47,14 @@
     "name:deu_x_preferred":[
         "B\u00e9ni Saf"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03bd\u03af \u03a3\u03b1\u03c6"
+    ],
     "name:eng_x_preferred":[
         "B\u00e9ni Saf"
+    ],
+    "name:eng_x_variant":[
+        "Beni Saf"
     ],
     "name:fas_x_preferred":[
         "\u0628\u0646\u06cc \u0635\u0627\u0641"
@@ -71,6 +83,9 @@
     "name:nld_x_preferred":[
         "B\u00e9ni Saf"
     ],
+    "name:nob_x_preferred":[
+        "Beni Saf"
+    ],
     "name:oci_x_preferred":[
         "B\u00e9ni Saf"
     ],
@@ -94,6 +109,9 @@
     ],
     "name:und_x_variant":[
         "Beni Sat"
+    ],
+    "name:uzb_x_preferred":[
+        "B\u00e9ni Saf"
     ],
     "name:vie_x_preferred":[
         "Beni Saf"
@@ -147,7 +165,7 @@
         }
     ],
     "wof:id":421185649,
-    "wof:lastmodified":1566583506,
+    "wof:lastmodified":1690875538,
     "wof:name":"Beni Saf",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/421/185/651/421185651.geojson
+++ b/data/421/185/651/421185651.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0628 \u0627\u0644\u0632\u0648\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0628 \u0627\u0644\u0632\u0648\u0627\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0627\u0628\u200c\u0627\u0644\u0632\u0648\u0627\u0631"
     ],
@@ -62,6 +65,9 @@
     "name:nld_x_preferred":[
         "Bab Ezzouar"
     ],
+    "name:nob_x_preferred":[
+        "Bab Ezzouar"
+    ],
     "name:oci_x_preferred":[
         "Bab Ezzouar"
     ],
@@ -80,6 +86,9 @@
     "name:swe_x_preferred":[
         "Bab Ezzouar"
     ],
+    "name:tur_x_preferred":[
+        "Bab\u00fc'z-Zuvar"
+    ],
     "name:und_x_variant":[
         "Le Retour de la Chasse"
     ],
@@ -94,6 +103,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Bab Ezzouar"
+    ],
+    "name:zho_x_preferred":[
+        "\u5df4\u5e03\u57c3\u7956\u74e6\u5c14"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -141,7 +153,7 @@
         }
     ],
     "wof:id":421185651,
-    "wof:lastmodified":1566583505,
+    "wof:lastmodified":1690875537,
     "wof:name":"Bab Ezzouar",
     "wof:parent_id":85670761,
     "wof:placetype":"locality",

--- a/data/421/185/653/421185653.geojson
+++ b/data/421/185/653/421185653.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u062a\u0631\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u062a\u0631\u0643"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u062a\u0631\u06a9"
     ],
@@ -47,6 +50,12 @@
     "name:ita_x_preferred":[
         "A\u00efn El Turk"
     ],
+    "name:kab_x_preferred":[
+        "\u0190in Tturk"
+    ],
+    "name:kor_x_preferred":[
+        "\uc544\uc778 \uc5d8 \ud22c\ub974\ud06c"
+    ],
     "name:msa_x_preferred":[
         "A\u00efn El Turk"
     ],
@@ -55,6 +64,9 @@
     ],
     "name:nld_x_preferred":[
         "A\u00efn El Turk"
+    ],
+    "name:pol_x_preferred":[
+        "Ajn at-Turk"
     ],
     "name:por_x_preferred":[
         "A\u00efn El Turk"
@@ -128,7 +140,7 @@
         }
     ],
     "wof:id":421185653,
-    "wof:lastmodified":1566583506,
+    "wof:lastmodified":1690875539,
     "wof:name":"Ain Turk",
     "wof:parent_id":85670689,
     "wof:placetype":"locality",

--- a/data/421/185/703/421185703.geojson
+++ b/data/421/185/703/421185703.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062d\u062c\u0648\u0637"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u062c\u0648\u0637"
+    ],
     "name:azb_x_preferred":[
         "\u062d\u062c\u0648\u0637"
     ],
@@ -35,6 +38,9 @@
     "name:fra_x_preferred":[
         "Hadjout"
     ],
+    "name:heb_x_preferred":[
+        "\u05d7\u05d2'\u05d5\u05d8"
+    ],
     "name:hun_x_preferred":[
         "Hadjout"
     ],
@@ -43,6 +49,9 @@
     ],
     "name:kab_x_preferred":[
         "\u1e24ejju\u1e6d"
+    ],
+    "name:kab_x_variant":[
+        "\u1e24e\u01e7\u01e7u\u1e6d"
     ],
     "name:msa_x_preferred":[
         "Hadjout"
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":421185703,
-    "wof:lastmodified":1566583505,
+    "wof:lastmodified":1690875537,
     "wof:name":"Hadjout",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/189/367/421189367.geojson
+++ b/data/421/189/367/421189367.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u0628\u0644\u062f\u064a\u0629 \u0627\u0644\u0645\u0631\u0633\u0649 \u0627\u0644\u0643\u0628\u064a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u0631\u0633\u0649 \u0627\u0644\u0643\u0628\u064a\u0631"
+    ],
     "name:ast_x_preferred":[
         "Mazalquivir"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:aze_x_preferred":[
         "Mers \u018fl K\u0259bir"
+    ],
+    "name:bul_x_preferred":[
+        "\u041c\u0435\u0440\u0441 \u0435\u043b-\u041a\u0435\u0431\u0438\u0440"
     ],
     "name:cat_x_preferred":[
         "Mers el-Kebir"
@@ -46,6 +52,9 @@
     ],
     "name:eng_x_preferred":[
         "Mers El K\u00e9bir"
+    ],
+    "name:eng_x_variant":[
+        "Mers El Kebir"
     ],
     "name:epo_x_preferred":[
         "Marsalkibir"
@@ -68,11 +77,17 @@
     "name:fra_x_variant":[
         "Saint Andr\u00e9 de Mers-el-K\u00e9bir"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05e8 \u05d0\u05dc \u05e7\u05d1\u05d9\u05e8"
+    ],
     "name:ita_x_preferred":[
         "Mers-el-K\u00e9bir"
     ],
     "name:jpn_x_preferred":[
         "\u30e1\u30eb\u30b9\u30fb\u30a8\u30eb\u30fb\u30b1\u30d3\u30fc\u30eb"
+    ],
+    "name:kab_x_preferred":[
+        "Lme\u1e5bsa Lekbir"
     ],
     "name:kor_x_preferred":[
         "\uba54\ub974\uc2a4\uc5d8\ucf00\ube44\ub974"
@@ -170,7 +185,7 @@
         }
     ],
     "wof:id":421189367,
-    "wof:lastmodified":1566583492,
+    "wof:lastmodified":1690875520,
     "wof:name":"Mers el Kebir",
     "wof:parent_id":85670689,
     "wof:placetype":"locality",

--- a/data/421/189/373/421189373.geojson
+++ b/data/421/189/373/421189373.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u062e\u0631\u0627\u0637\u0629\u060c\u0628\u062c\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062e\u0631\u0627\u0637\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062e\u0631\u0627\u0637\u0647"
     ],
@@ -41,6 +44,9 @@
     "name:kab_x_preferred":[
         "Xerra\u1e6d\u1e6da"
     ],
+    "name:kab_x_variant":[
+        "Xerra\u1e6da"
+    ],
     "name:msa_x_preferred":[
         "Kherrata"
     ],
@@ -48,6 +54,9 @@
         "Kherrata"
     ],
     "name:nld_x_preferred":[
+        "Kherrata"
+    ],
+    "name:pol_x_preferred":[
         "Kherrata"
     ],
     "name:por_x_preferred":[
@@ -70,6 +79,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6d77\u62c9\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Kherrata"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -116,7 +128,7 @@
         }
     ],
     "wof:id":421189373,
-    "wof:lastmodified":1566583492,
+    "wof:lastmodified":1690875520,
     "wof:name":"Kherrata",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/189/561/421189561.geojson
+++ b/data/421/189/561/421189561.geojson
@@ -20,10 +20,22 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0637\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0637\u0627\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0637\u0627\u06cc\u0647"
     ],
+    "name:cat_x_preferred":[
+        "A\u00efn Taia"
+    ],
     "name:ceb_x_preferred":[
+        "A\u00efn Taya"
+    ],
+    "name:dan_x_preferred":[
+        "A\u00efn Taya"
+    ],
+    "name:deu_x_preferred":[
         "A\u00efn Taya"
     ],
     "name:eng_x_preferred":[
@@ -37,6 +49,9 @@
     ],
     "name:ita_x_preferred":[
         "A\u00efn Taya"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30a4\u30f3\u30fb\u30bf\u30e4"
     ],
     "name:kab_x_preferred":[
         "\u0190in \u1e6caya"
@@ -62,11 +77,20 @@
     "name:swe_x_preferred":[
         "A\u00efn Taya"
     ],
+    "name:tur_x_preferred":[
+        "Ayn Taya"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0410\u0439\u043d-\u0422\u0430\u0439\u0430"
+    ],
     "name:urd_x_preferred":[
         "\u0639\u06cc\u0646 \u0637\u0627\u06cc\u06c1"
     ],
     "name:vie_x_preferred":[
         "Ain Taya"
+    ],
+    "name:zho_x_preferred":[
+        "\u827e\u56e0\u5854\u4e9a"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -111,7 +135,7 @@
         }
     ],
     "wof:id":421189561,
-    "wof:lastmodified":1566583491,
+    "wof:lastmodified":1690875519,
     "wof:name":"'Ain Taya",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/190/887/421190887.geojson
+++ b/data/421/190/887/421190887.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u062f\u064a\u0629 \u062f\u0648\u064a\u0631\u0629"
     ],
+    "name:ara_x_variant":[
+        "\u0627\u0644\u062f\u0648\u064a\u0631\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062f\u0648\u064a\u0631\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u0648\u06cc\u0631\u0647"
     ],
@@ -61,6 +67,9 @@
     ],
     "name:swe_x_preferred":[
         "Douera"
+    ],
+    "name:tur_x_preferred":[
+        "Duveyre"
     ],
     "name:urd_x_preferred":[
         "\u062f\u0648\u06cc\u0631\u06c1"
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":421190887,
-    "wof:lastmodified":1566583497,
+    "wof:lastmodified":1690875527,
     "wof:name":"Douera",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/190/889/421190889.geojson
+++ b/data/421/190/889/421190889.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0639\u0637\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u0637\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0637\u0641"
+    ],
+    "name:deu_x_preferred":[
+        "El Atteuf"
     ],
     "name:eng_x_preferred":[
         "El Atteuf"
@@ -32,11 +38,17 @@
     "name:fra_x_preferred":[
         "El Atteuf"
     ],
+    "name:ind_x_preferred":[
+        "El Atteuf"
+    ],
     "name:ita_x_preferred":[
         "El Atteuf"
     ],
     "name:jpn_x_preferred":[
         "\u30a8\u30eb\uff1d\u30a2\u30c3\u30c8\u30a5\u30d5"
+    ],
+    "name:kab_x_preferred":[
+        "L\u025ba\u1e6def"
     ],
     "name:msa_x_preferred":[
         "El Atteuf"
@@ -106,7 +118,7 @@
         }
     ],
     "wof:id":421190889,
-    "wof:lastmodified":1566583497,
+    "wof:lastmodified":1690875527,
     "wof:name":"El Ateuf",
     "wof:parent_id":85670749,
     "wof:placetype":"locality",

--- a/data/421/190/891/421190891.geojson
+++ b/data/421/190/891/421190891.geojson
@@ -16,7 +16,70 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "La Tribu"
+    ],
+    "name:cat_x_preferred":[
+        "La Tribu"
+    ],
+    "name:dan_x_preferred":[
+        "La Tribu"
+    ],
+    "name:deu_x_preferred":[
+        "La Tribu"
+    ],
     "name:eng_x_preferred":[
+        "La Tribu"
+    ],
+    "name:eus_x_preferred":[
+        "La Tribu"
+    ],
+    "name:fin_x_preferred":[
+        "La Tribu"
+    ],
+    "name:fra_x_preferred":[
+        "La Tribu"
+    ],
+    "name:gle_x_preferred":[
+        "La Tribu"
+    ],
+    "name:hun_x_preferred":[
+        "La Tribu"
+    ],
+    "name:ita_x_preferred":[
+        "La Tribu"
+    ],
+    "name:nld_x_preferred":[
+        "La Tribu"
+    ],
+    "name:nno_x_preferred":[
+        "La Tribu"
+    ],
+    "name:nob_x_preferred":[
+        "La Tribu"
+    ],
+    "name:pol_x_preferred":[
+        "La Tribu"
+    ],
+    "name:por_x_preferred":[
+        "La Tribu"
+    ],
+    "name:ron_x_preferred":[
+        "La Tribu"
+    ],
+    "name:sme_x_preferred":[
+        "La Tribu"
+    ],
+    "name:spa_x_preferred":[
+        "La Tribu"
+    ],
+    "name:sqi_x_preferred":[
+        "La Tribu"
+    ],
+    "name:swe_x_preferred":[
+        "La Tribu"
+    ],
+    "name:tur_x_preferred":[
         "La Tribu"
     ],
     "qs:gn_country":"DZ",
@@ -64,7 +127,7 @@
         }
     ],
     "wof:id":421190891,
-    "wof:lastmodified":1566583498,
+    "wof:lastmodified":1690875527,
     "wof:name":"La Tribu",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/191/587/421191587.geojson
+++ b/data/421/191/587/421191587.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062d\u0645\u062f\u0627\u0646\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u0645\u062f\u0627\u0646\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062d\u0645\u062f\u0627\u0646\u06cc\u0647"
     ],
@@ -54,6 +57,9 @@
         "El Hamdania"
     ],
     "name:spa_x_preferred":[
+        "El Hamdania"
+    ],
+    "name:uzb_x_preferred":[
         "El Hamdania"
     ],
     "name:vie_x_preferred":[
@@ -110,7 +116,7 @@
         }
     ],
     "wof:id":421191587,
-    "wof:lastmodified":1566583497,
+    "wof:lastmodified":1690875526,
     "wof:name":"El Hamdania",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/192/351/421192351.geojson
+++ b/data/421/192/351/421192351.geojson
@@ -29,11 +29,20 @@
     "name:eng_x_preferred":[
         "Chr\u00e9a"
     ],
+    "name:eng_x_variant":[
+        "Chrea"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0634\u0631\u06cc\u0639\u0647"
     ],
     "name:fra_x_preferred":[
         "Chr\u00e9a"
+    ],
+    "name:ita_x_preferred":[
+        "Chr\u00e9a"
+    ],
+    "name:kab_x_preferred":[
+        "Ccri\u025ba"
     ],
     "name:msa_x_preferred":[
         "Chr\u00e9a"
@@ -64,6 +73,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4ec0\u91cc\u963f"
+    ],
+    "name:zul_x_preferred":[
+        "Chr\u00e9a"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421192351,
-    "wof:lastmodified":1566583482,
+    "wof:lastmodified":1690875509,
     "wof:name":"Chrea",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/192/353/421192353.geojson
+++ b/data/421/192/353/421192353.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_variant":[
         "\u0628\u0644\u062f\u064a\u0629 \u0627\u0644\u0642\u0628\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0642\u0628\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0628\u0647"
     ],
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":421192353,
-    "wof:lastmodified":1566583481,
+    "wof:lastmodified":1690875509,
     "wof:name":"Kouba",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/192/361/421192361.geojson
+++ b/data/421/192/361/421192361.geojson
@@ -23,6 +23,9 @@
     "name:fas_x_preferred":[
         "\u0627\u0633\u200c\u0627\u0633 \u0645\u0644\u06cc\u06a9\u0627"
     ],
+    "name:gle_x_preferred":[
+        "SS Melika"
+    ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2488264,
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":421192361,
-    "wof:lastmodified":1566583482,
+    "wof:lastmodified":1690875509,
     "wof:name":"Melika",
     "wof:parent_id":85670749,
     "wof:placetype":"locality",

--- a/data/421/192/365/421192365.geojson
+++ b/data/421/192/365/421192365.geojson
@@ -46,8 +46,14 @@
     "name:cat_x_preferred":[
         "Mustafa"
     ],
+    "name:cat_x_variant":[
+        "M\u00fastafa"
+    ],
     "name:ces_x_preferred":[
         "Mustafa"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0645\u0648\u0633\u062a\u06d5\u0641\u0627"
     ],
     "name:cos_x_preferred":[
         "Mustafa"
@@ -136,8 +142,14 @@
     "name:jpn_x_preferred":[
         "\u30e0\u30b9\u30bf\u30d5\u30a1"
     ],
+    "name:kaz_x_preferred":[
+        "\u041c\u04b1\u0441\u0442\u0430\u0444\u0430"
+    ],
     "name:kon_x_preferred":[
         "Mustafa"
+    ],
+    "name:kor_x_preferred":[
+        "\ubb34\uc2a4\ud0c0\ud30c"
     ],
     "name:lat_x_preferred":[
         "Mustapha"
@@ -222,6 +234,9 @@
     ],
     "name:slv_x_preferred":[
         "Mustafa"
+    ],
+    "name:snd_x_preferred":[
+        "\u0645\u0635\u0637\u0641\u064a"
     ],
     "name:spa_x_preferred":[
         "Mustaf\u00e1"
@@ -325,7 +340,7 @@
         }
     ],
     "wof:id":421192365,
-    "wof:lastmodified":1566583481,
+    "wof:lastmodified":1690875508,
     "wof:name":"Mustapha",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/193/211/421193211.geojson
+++ b/data/421/193/211/421193211.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0626\u0631 \u062e\u0627\u062f\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0626\u0631 \u062e\u0627\u062f\u0645"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0626\u0631 \u062e\u0627\u062f\u0645"
+    ],
+    "name:aze_x_preferred":[
+        "Birxad\u0259m"
     ],
     "name:ceb_x_preferred":[
         "Birkhadem"
@@ -74,6 +80,9 @@
     "name:swe_x_preferred":[
         "Birkhadem"
     ],
+    "name:tur_x_preferred":[
+        "Bir Hadim"
+    ],
     "name:und_x_variant":[
         "Birkadem"
     ],
@@ -85,6 +94,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Birkhadem"
+    ],
+    "name:zho_x_preferred":[
+        "\u6bd4\u5c14\u54c8\u8fea\u59c6"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -132,7 +144,7 @@
         }
     ],
     "wof:id":421193211,
-    "wof:lastmodified":1566583484,
+    "wof:lastmodified":1690875511,
     "wof:name":"Birkhadem",
     "wof:parent_id":85670761,
     "wof:placetype":"locality",

--- a/data/421/193/227/421193227.geojson
+++ b/data/421/193/227/421193227.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0631\u0648\u0627\u0634\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u0648\u0627\u0634\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0648\u0627\u0634\u062f"
+    ],
+    "name:ceb_x_preferred":[
+        "Rouached"
     ],
     "name:eng_x_preferred":[
         "Rouached"
@@ -34,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Rouached"
+    ],
+    "name:kab_x_preferred":[
+        "Rrwaced"
     ],
     "name:msa_x_preferred":[
         "Rouached"
@@ -51,6 +60,9 @@
         "Rouached"
     ],
     "name:spa_x_preferred":[
+        "Rouached"
+    ],
+    "name:swe_x_preferred":[
         "Rouached"
     ],
     "name:vie_x_preferred":[
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":421193227,
-    "wof:lastmodified":1566583484,
+    "wof:lastmodified":1690875511,
     "wof:name":"Rouached",
     "wof:parent_id":85670867,
     "wof:placetype":"locality",

--- a/data/421/194/045/421194045.geojson
+++ b/data/421/194/045/421194045.geojson
@@ -20,16 +20,31 @@
     "name:ara_x_preferred":[
         "\u0622\u0641\u0644\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0641\u0644\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Aflou"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0641\u0644\u0648"
     ],
+    "name:aze_x_preferred":[
+        "\u018ffl\u00fc"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09ab\u09cd\u09b2\u09c1"
+    ],
+    "name:cat_x_preferred":[
+        "Aflou"
     ],
     "name:ceb_x_preferred":[
         "Aflou"
     ],
     "name:dan_x_preferred":[
+        "Aflou"
+    ],
+    "name:deu_x_preferred":[
         "Aflou"
     ],
     "name:ell_x_preferred":[
@@ -119,6 +134,9 @@
     "name:spa_x_preferred":[
         "Aflou"
     ],
+    "name:swa_x_preferred":[
+        "Aflou"
+    ],
     "name:swe_x_preferred":[
         "Aflou"
     ],
@@ -148,6 +166,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u592b\u5362"
+    ],
+    "name:zul_x_preferred":[
+        "Aflou"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -197,7 +218,7 @@
         }
     ],
     "wof:id":421194045,
-    "wof:lastmodified":1566583484,
+    "wof:lastmodified":1690875510,
     "wof:name":"Aflou",
     "wof:parent_id":85670753,
     "wof:placetype":"locality",

--- a/data/421/194/227/421194227.geojson
+++ b/data/421/194/227/421194227.geojson
@@ -23,8 +23,14 @@
     "name:ara_x_variant":[
         "\u0628\u0644\u062f\u064a\u0629 \u0627\u0644\u0631\u0648\u064a\u0628\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u0648\u064a\u0628\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0648\u06cc\u0628\u0647"
+    ],
+    "name:cat_x_preferred":[
+        "Rou\u00efba"
     ],
     "name:ceb_x_preferred":[
         "Rouiba"
@@ -35,6 +41,9 @@
     "name:eng_x_preferred":[
         "Rou\u00efba"
     ],
+    "name:eng_x_variant":[
+        "Rouiba"
+    ],
     "name:fas_x_preferred":[
         "\u0631\u0648\u06cc\u0628\u0647"
     ],
@@ -43,6 +52,9 @@
     ],
     "name:ita_x_preferred":[
         "Rou\u00efba"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30eb\u30a4\u30d0"
     ],
     "name:kab_x_preferred":[
         "Rrwiba"
@@ -73,6 +85,12 @@
     ],
     "name:swe_x_preferred":[
         "Rouiba"
+    ],
+    "name:tur_x_preferred":[
+        "Ruveybe"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0420\u0443\u0457\u0431\u0430"
     ],
     "name:urd_x_preferred":[
         "\u0631\u0648\u0628\u06cc\u06c1"
@@ -126,7 +144,7 @@
         }
     ],
     "wof:id":421194227,
-    "wof:lastmodified":1566583484,
+    "wof:lastmodified":1690875510,
     "wof:name":"Rouiba",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/194/585/421194585.geojson
+++ b/data/421/194/585/421194585.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0628\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0628\u0644\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0628\u0644\u06cc"
     ],
@@ -68,6 +71,9 @@
     "name:vie_x_preferred":[
         "Chebli"
     ],
+    "name:zul_x_preferred":[
+        "Ch\u00e9bli"
+    ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2501680,
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":421194585,
-    "wof:lastmodified":1566583484,
+    "wof:lastmodified":1690875511,
     "wof:name":"Chebli",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/195/165/421195165.geojson
+++ b/data/421/195/165/421195165.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0623\u0631\u0632\u064a\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0631\u0632\u064a\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Arzew"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0631\u0632\u06cc\u0648"
+    ],
+    "name:aze_x_preferred":[
+        "\u018frzev"
     ],
     "name:cat_x_preferred":[
         "Arzew"
@@ -44,11 +53,20 @@
     "name:fra_x_variant":[
         "Saint-Leu"
     ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05e8\u05d6\u05d9\u05d5"
+    ],
     "name:ita_x_preferred":[
         "Arzew"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30eb\u30bc\u30a6"
+    ],
+    "name:kab_x_preferred":[
+        "Arziw"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10e0\u10d6\u10d4\u10d5\u10d8"
     ],
     "name:lit_x_preferred":[
         "Arzeu"
@@ -60,6 +78,9 @@
         "Arzew"
     ],
     "name:nld_x_preferred":[
+        "Arzew"
+    ],
+    "name:nob_x_preferred":[
         "Arzew"
     ],
     "name:pol_x_preferred":[
@@ -136,7 +157,7 @@
         }
     ],
     "wof:id":421195165,
-    "wof:lastmodified":1566583483,
+    "wof:lastmodified":1690875509,
     "wof:name":"Arzew",
     "wof:parent_id":85670689,
     "wof:placetype":"locality",

--- a/data/421/195/271/421195271.geojson
+++ b/data/421/195/271/421195271.geojson
@@ -23,8 +23,17 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u063a\u0631\u062f\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u063a\u0631\u062f\u0627\u064a\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Ghardaia"
+    ],
     "name:azb_x_preferred":[
         "\u063a\u0631\u062f\u0627\u06cc\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Q\u0259rdaya"
     ],
     "name:ben_x_preferred":[
         "\u0997\u09be\u09b0\u09cd\u09a1\u09bf\u09af\u09bc\u09be"
@@ -49,6 +58,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03b1\u03c1\u03bd\u03c4\u03ac\u03b9\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0393\u03ba\u03b1\u03c1\u03bd\u03c4\u03ac\u03b9\u03b1"
     ],
     "name:eng_x_preferred":[
         "Gharda\u00efa"
@@ -80,6 +92,9 @@
     "name:hin_x_preferred":[
         "\u0918\u0930\u0926\u093f\u092f\u093e"
     ],
+    "name:hye_x_preferred":[
+        "\u0533\u0561\u0580\u0564\u0561\u0575\u0561"
+    ],
     "name:ind_x_preferred":[
         "Gharda\u00efa"
     ],
@@ -91,6 +106,9 @@
     ],
     "name:kab_x_preferred":[
         "Ta\u03b3erdayt"
+    ],
+    "name:kab_x_variant":[
+        "Ta\u0263erdayt"
     ],
     "name:kan_x_preferred":[
         "\u0c98\u0cbe\u0cb0\u0ccd\u0ca1\u0cbf\u0caf\u0cbe"
@@ -235,7 +253,7 @@
         }
     ],
     "wof:id":421195271,
-    "wof:lastmodified":1566583483,
+    "wof:lastmodified":1690875509,
     "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u063a\u0631\u062f\u0627\u064a\u0629",
     "wof:parent_id":85670749,
     "wof:placetype":"locality",

--- a/data/421/195/457/421195457.geojson
+++ b/data/421/195/457/421195457.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u0642\u0648\u0631\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0648\u0631\u0627\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0648\u0631\u0627\u06cc\u0647"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:ita_x_preferred":[
         "Gouraya"
+    ],
+    "name:kab_x_preferred":[
+        "Guraya"
     ],
     "name:msa_x_preferred":[
         "Gouraya"
@@ -105,7 +111,7 @@
         }
     ],
     "wof:id":421195457,
-    "wof:lastmodified":1566583483,
+    "wof:lastmodified":1690875510,
     "wof:name":"Gouraya",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/195/721/421195721.geojson
+++ b/data/421/195/721/421195721.geojson
@@ -23,11 +23,23 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u0628\u0633\u0643\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0633\u0643\u0631\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Biskra"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0633\u06a9\u0631\u0647"
     ],
+    "name:aze_x_preferred":[
+        "Biskra"
+    ],
     "name:bak_x_preferred":[
         "\u0411\u0438\u0441\u043a\u0440\u0430"
+    ],
+    "name:bel_x_preferred":[
+        "\u0411\u0456\u0441\u043a\u0440\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09bf\u09b8\u0995\u09cd\u09b0\u09be"
@@ -62,6 +74,9 @@
     "name:epo_x_preferred":[
         "Biskra"
     ],
+    "name:est_x_preferred":[
+        "Biskra"
+    ],
     "name:eus_x_preferred":[
         "Biskra"
     ],
@@ -77,6 +92,12 @@
     "name:fra_x_preferred":[
         "Biskra"
     ],
+    "name:frr_x_preferred":[
+        "Biskra"
+    ],
+    "name:gle_x_preferred":[
+        "Biskra"
+    ],
     "name:guj_x_preferred":[
         "\u0aac\u0abf\u0ab8\u0acd\u0a95\u0acd\u0ab0\u0acd\u0ab0\u0abe"
     ],
@@ -85,6 +106,9 @@
     ],
     "name:hrv_x_preferred":[
         "Biskra"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u056b\u057d\u056f\u0580\u0561"
     ],
     "name:ind_x_preferred":[
         "Biskra"
@@ -106,6 +130,9 @@
     ],
     "name:kor_x_preferred":[
         "\ube44\uc2a4\ud06c\ub77c"
+    ],
+    "name:lat_x_preferred":[
+        "Vescera"
     ],
     "name:lav_x_preferred":[
         "Biskra"
@@ -149,6 +176,9 @@
     "name:spa_x_preferred":[
         "Biskra"
     ],
+    "name:swa_x_preferred":[
+        "Biskra"
+    ],
     "name:swe_x_preferred":[
         "Biskra"
     ],
@@ -173,6 +203,9 @@
     "name:urd_x_preferred":[
         "\u0628\u06cc\u0633\u06a9\u0631\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Biskra"
+    ],
     "name:vie_x_preferred":[
         "Biskra"
     ],
@@ -181,6 +214,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6bd4\u65af\u514b\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Biskra"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPLA",
@@ -226,7 +262,7 @@
         }
     ],
     "wof:id":421195721,
-    "wof:lastmodified":1566583483,
+    "wof:lastmodified":1690875510,
     "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0628\u0633\u0643\u0631\u0629",
     "wof:parent_id":85670827,
     "wof:placetype":"locality",

--- a/data/421/196/001/421196001.geojson
+++ b/data/421/196/001/421196001.geojson
@@ -26,14 +26,29 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u0633\u0637\u064a\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0637\u064a\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "S\u00e9tif"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0637\u06cc\u0641"
+    ],
+    "name:aze_x_preferred":[
+        "S\u0259tif"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0435\u0442\u044b\u0444"
     ],
+    "name:bel_x_variant":[
+        "\u0421\u0435\u0442\u044b\u0444"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u099f\u09bf\u09ab"
+    ],
+    "name:ben_x_variant":[
+        "\u09b8\u09c7\u09a4\u09bf\u09ab"
     ],
     "name:bre_x_preferred":[
         "Setif"
@@ -45,6 +60,9 @@
         "Sitifis"
     ],
     "name:ceb_x_preferred":[
+        "S\u00e9tif"
+    ],
+    "name:ces_x_preferred":[
         "S\u00e9tif"
     ],
     "name:dan_x_preferred":[
@@ -75,6 +93,12 @@
         "S\u00e9tif"
     ],
     "name:fra_x_preferred":[
+        "S\u00e9tif"
+    ],
+    "name:frr_x_preferred":[
+        "S\u00e9tif"
+    ],
+    "name:gle_x_preferred":[
         "S\u00e9tif"
     ],
     "name:guj_x_preferred":[
@@ -143,6 +167,12 @@
     "name:nob_x_preferred":[
         "S\u00e9tif"
     ],
+    "name:oci_x_preferred":[
+        "Setif"
+    ],
+    "name:oss_x_preferred":[
+        "\u0421\u0435\u0442\u0438\u0444"
+    ],
     "name:pnb_x_preferred":[
         "\u0633\u0637\u0641"
     ],
@@ -170,6 +200,9 @@
     "name:spa_x_preferred":[
         "S\u00e9tif"
     ],
+    "name:swa_x_preferred":[
+        "S\u00e9tif"
+    ],
     "name:swe_x_preferred":[
         "S\u00e9tif"
     ],
@@ -193,6 +226,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0633\u0637\u06cc\u0641"
+    ],
+    "name:vec_x_preferred":[
+        "S\u00e9tif"
     ],
     "name:vie_x_preferred":[
         "S\u00e9tif"
@@ -247,7 +283,7 @@
         }
     ],
     "wof:id":421196001,
-    "wof:lastmodified":1566583496,
+    "wof:lastmodified":1690875525,
     "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0633\u0637\u064a\u0641",
     "wof:parent_id":85670845,
     "wof:placetype":"locality",

--- a/data/421/196/119/421196119.geojson
+++ b/data/421/196/119/421196119.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0623\u062f\u0631\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u062f\u0631\u0627\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Adrar"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u0631\u0627\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fdrar"
     ],
     "name:cat_x_preferred":[
         "Adrar"
@@ -34,6 +43,9 @@
     ],
     "name:deu_x_preferred":[
         "Adrar"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bd\u03c4\u03c1\u03ac\u03c1"
     ],
     "name:eng_x_preferred":[
         "Adrar"
@@ -64,6 +76,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30c9\u30e9\u30fc\u30eb"
+    ],
+    "name:kab_x_preferred":[
+        "Adrar"
     ],
     "name:kor_x_preferred":[
         "\uc544\ub4dc\ub77c\ub974"
@@ -98,11 +113,17 @@
     "name:spa_x_preferred":[
         "Adrar"
     ],
+    "name:swa_x_preferred":[
+        "Adrar"
+    ],
     "name:swe_x_preferred":[
         "Adrar"
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e32\u0e14\u0e23\u0e32\u0e23\u0e4c"
+    ],
+    "name:tha_x_variant":[
+        "\u0e2d\u0e31\u0e14\u0e23\u0e2d\u0e23"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0434\u0440\u0430\u0440"
@@ -121,6 +142,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u5fb7\u62c9\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "Adrar"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -167,7 +191,7 @@
         }
     ],
     "wof:id":421196119,
-    "wof:lastmodified":1566583496,
+    "wof:lastmodified":1690875525,
     "wof:name":"\u0648\u0644\u0627\u064a\u0629 \u0623\u062f\u0631\u0627\u0631",
     "wof:parent_id":85670677,
     "wof:placetype":"locality",

--- a/data/421/196/635/421196635.geojson
+++ b/data/421/196/635/421196635.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a \u0645\u0631\u0627\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u0649 \u0645\u0631\u0627\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc \u0645\u0631\u0627\u062f"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:eng_x_preferred":[
         "B\u00e9ni Mered"
+    ],
+    "name:eng_x_variant":[
+        "Beni Mered"
     ],
     "name:fas_x_preferred":[
         "\u0628\u0646\u06cc \u0645\u0631\u0627\u062f"
@@ -67,6 +73,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Beni Mered"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9ni Mered"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":421196635,
-    "wof:lastmodified":1566583495,
+    "wof:lastmodified":1690875524,
     "wof:name":"Beni Mered",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/196/637/421196637.geojson
+++ b/data/421/196/637/421196637.geojson
@@ -20,8 +20,20 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u062f\u0648\u0627\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u062f\u0648\u0627\u0648"
+    ],
+    "name:aze_x_preferred":[
+        "Buduau"
+    ],
     "name:ceb_x_preferred":[
         "Boudouaou"
+    ],
+    "name:deu_x_preferred":[
+        "Boudouaou"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03c5\u03bd\u03c4\u03bf\u03c5\u03b1\u03bf\u03cd"
     ],
     "name:eng_x_preferred":[
         "Boudouaou"
@@ -117,7 +129,7 @@
         }
     ],
     "wof:id":421196637,
-    "wof:lastmodified":1566583497,
+    "wof:lastmodified":1690875526,
     "wof:name":"Boudouaou",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/196/657/421196657.geojson
+++ b/data/421/196/657/421196657.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u0639\u0645\u0631\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0639\u0645\u0631\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0639\u0645\u0631\u0627\u0646"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Sidi Amrane"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30c7\u30a3\u30fb\u30a2\u30e0\u30e9\u30cd"
     ],
     "name:msa_x_preferred":[
         "Sidi Amrane"
@@ -111,7 +117,7 @@
         }
     ],
     "wof:id":421196657,
-    "wof:lastmodified":1566583496,
+    "wof:lastmodified":1690875525,
     "wof:name":"Sidi Amrane",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",

--- a/data/421/196/675/421196675.geojson
+++ b/data/421/196/675/421196675.geojson
@@ -23,8 +23,14 @@
     "name:ara_x_variant":[
         "\u0639\u064a\u0646 \u0645\u0631\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0645\u0631\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0645\u0631\u0627\u0646"
+    ],
+    "name:ceb_x_preferred":[
+        "'A\u00efn Merane"
     ],
     "name:eng_x_preferred":[
         "Ain Merane"
@@ -44,6 +50,9 @@
     "name:ita_x_variant":[
         "A\u00efn Merane"
     ],
+    "name:kab_x_preferred":[
+        "\u0190in Merran"
+    ],
     "name:msa_x_preferred":[
         "Ain Merane"
     ],
@@ -59,6 +68,9 @@
     "name:ron_x_preferred":[
         "A\u00efn Merane"
     ],
+    "name:swe_x_preferred":[
+        "'A\u00efn Merane"
+    ],
     "name:und_x_variant":[
         "Rabelais"
     ],
@@ -73,6 +85,9 @@
     ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u9081\u862d"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Merane"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -118,7 +133,7 @@
         }
     ],
     "wof:id":421196675,
-    "wof:lastmodified":1566583495,
+    "wof:lastmodified":1690875524,
     "wof:name":"'Ain Merane",
     "wof:parent_id":85670781,
     "wof:placetype":"locality",

--- a/data/421/196/681/421196681.geojson
+++ b/data/421/196/681/421196681.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062f\u0627\u0631 \u0627\u0644\u0634\u064a\u0648\u062e"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0627\u0631 \u0627\u0644\u0634\u064a\u0648\u062e"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u0627\u0631 \u0634\u06cc\u0648\u062e"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Dar Chioukh"
+    ],
+    "name:kab_x_preferred":[
+        "Dar Ccyux"
     ],
     "name:msa_x_preferred":[
         "Dar Chioukh"
@@ -117,7 +123,7 @@
         }
     ],
     "wof:id":421196681,
-    "wof:lastmodified":1566583495,
+    "wof:lastmodified":1690875524,
     "wof:name":"Dar Chioukh",
     "wof:parent_id":85670833,
     "wof:placetype":"locality",

--- a/data/421/196/683/421196683.geojson
+++ b/data/421/196/683/421196683.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0642\u0635\u0631 \u0627\u0644\u0628\u062e\u0627\u0631\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0635\u0631 \u0627\u0644\u0628\u062e\u0627\u0631\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0635\u0631 \u0628\u062e\u0627\u0631\u06cc"
     ],
@@ -47,6 +50,9 @@
     "name:kab_x_preferred":[
         "Q\u1e63er Buxari"
     ],
+    "name:kab_x_variant":[
+        "Q\u1e63er Lbuxari"
+    ],
     "name:msa_x_preferred":[
         "Ksar Boukhari"
     ],
@@ -73,6 +79,9 @@
     ],
     "name:und_x_variant":[
         "Borhari"
+    ],
+    "name:uzb_x_preferred":[
+        "Ksar Boukhari"
     ],
     "name:vie_x_preferred":[
         "Ksar El Boukhari"
@@ -129,7 +138,7 @@
         }
     ],
     "wof:id":421196683,
-    "wof:lastmodified":1566583496,
+    "wof:lastmodified":1690875526,
     "wof:name":"Ksar el Boukhari",
     "wof:parent_id":85670837,
     "wof:placetype":"locality",

--- a/data/421/196/685/421196685.geojson
+++ b/data/421/196/685/421196685.geojson
@@ -35,8 +35,14 @@
     "name:fra_x_preferred":[
         "Mansoura"
     ],
+    "name:glg_x_preferred":[
+        "Mansoura"
+    ],
     "name:ita_x_preferred":[
         "Mansoura"
+    ],
+    "name:kab_x_preferred":[
+        "Lmen\u1e63ura"
     ],
     "name:msa_x_preferred":[
         "Mansoura"
@@ -61,6 +67,9 @@
     ],
     "name:swe_x_preferred":[
         "Mansourah"
+    ],
+    "name:uzb_x_preferred":[
+        "Mansoura"
     ],
     "name:vie_x_preferred":[
         "Mansoura"
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":421196685,
-    "wof:lastmodified":1566583496,
+    "wof:lastmodified":1690875525,
     "wof:name":"Mansourah",
     "wof:parent_id":85670809,
     "wof:placetype":"locality",

--- a/data/421/196/687/421196687.geojson
+++ b/data/421/196/687/421196687.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0645\u0627\u0634"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0645\u0627\u0634"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0648\u0645\u0627\u0634"
     ],
@@ -68,6 +71,9 @@
     "name:zho_min_nan_x_preferred":[
         "Oumache"
     ],
+    "name:zul_x_preferred":[
+        "Oumache"
+    ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2484738,
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":421196687,
-    "wof:lastmodified":1566583495,
+    "wof:lastmodified":1690875524,
     "wof:name":"Oumache",
     "wof:parent_id":85670827,
     "wof:placetype":"locality",

--- a/data/421/196/691/421196691.geojson
+++ b/data/421/196/691/421196691.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u0639\u064a\u0633\u0649"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0639\u064a\u0633\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Sidi A\u00efssa"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:ita_x_preferred":[
         "Sidi A\u00efssa"
+    ],
+    "name:kab_x_preferred":[
+        "Sidi \u0190isa"
     ],
     "name:msa_x_preferred":[
         "Sidi A\u00efssa"
@@ -64,6 +70,9 @@
     ],
     "name:und_x_variant":[
         "Sid A\u00efssa"
+    ],
+    "name:uzb_x_preferred":[
+        "Sidi Aissa"
     ],
     "name:vie_x_preferred":[
         "Sidi Aissa"
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":421196691,
-    "wof:lastmodified":1566583497,
+    "wof:lastmodified":1690875526,
     "wof:name":"Sidi Aissa",
     "wof:parent_id":85670841,
     "wof:placetype":"locality",

--- a/data/421/196/695/421196695.geojson
+++ b/data/421/196/695/421196695.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0627\u062f\u0645\u0627\u064a\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0627\u062f\u0645\u0627\u064a\u062a"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0627\u062f\u0645\u0627\u06cc\u062a"
     ],
@@ -80,6 +83,9 @@
     "name:zho_x_preferred":[
         "\u5854\u5fb7\u99ac\u4f0a\u7279"
     ],
+    "name:zul_x_preferred":[
+        "Tadma\u00eft"
+    ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":2478831,
@@ -126,7 +132,7 @@
         }
     ],
     "wof:id":421196695,
-    "wof:lastmodified":1566583496,
+    "wof:lastmodified":1690875524,
     "wof:name":"Tadmait",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/421/197/477/421197477.geojson
+++ b/data/421/197/477/421197477.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0632\u064a \u0646\u062b\u0644\u0627\u062b\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0632\u0649 \u0646\u062b\u0644\u0627\u062b\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0632\u06cc \u0646\u062b\u0644\u0627\u062b\u0647"
+    ],
+    "name:ceb_x_preferred":[
+        "Tizi-n-Tleta"
     ],
     "name:eng_x_preferred":[
         "Tizi N'Tleta"
@@ -59,11 +65,20 @@
     "name:spa_x_preferred":[
         "Tizi N'Tleta"
     ],
+    "name:swe_x_preferred":[
+        "Tizi-n-Tleta"
+    ],
+    "name:uzb_x_preferred":[
+        "Tizi N'Tleta"
+    ],
     "name:vie_x_preferred":[
         "Tizi N'Tleta"
     ],
     "name:zho_x_preferred":[
         "\u63d0\u6fdf\u6069\u7279\u840a\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Tizi N'Tleta"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -110,7 +125,7 @@
         }
     ],
     "wof:id":421197477,
-    "wof:lastmodified":1566583498,
+    "wof:lastmodified":1690875527,
     "wof:name":"Tizi-n-Tleta",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/197/479/421197479.geojson
+++ b/data/421/197/479/421197479.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0639\u0641\u0631\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u0641\u0631\u0648\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0641\u0631\u0648\u0646"
     ],
@@ -35,11 +38,17 @@
     "name:fra_x_preferred":[
         "El Affroun"
     ],
+    "name:glg_x_preferred":[
+        "El Affroun"
+    ],
     "name:ita_x_preferred":[
         "El Affroun"
     ],
     "name:jpn_x_preferred":[
         "\u30a8\u30eb\u30a2\u30d5\u30a9\u30ed\u30f3"
+    ],
+    "name:kab_x_preferred":[
+        "L\u025befrun"
     ],
     "name:msa_x_preferred":[
         "El Affroun"
@@ -72,6 +81,12 @@
         "El-Affroun"
     ],
     "name:zho_min_nan_x_preferred":[
+        "El Affroun"
+    ],
+    "name:zho_x_preferred":[
+        "\u57c3\u5c14\u5f17\u6d1b\u6069"
+    ],
+    "name:zul_x_preferred":[
         "El Affroun"
     ],
     "qs:gn_country":"DZ",
@@ -120,7 +135,7 @@
         }
     ],
     "wof:id":421197479,
-    "wof:lastmodified":1566583498,
+    "wof:lastmodified":1690875528,
     "wof:name":"El Afroun",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/197/481/421197481.geojson
+++ b/data/421/197/481/421197481.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0642\u0627\u0639\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0642\u0627\u0639\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u0642\u0627\u0639\u0647"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:kab_x_preferred":[
         "Buge\u025b\u025ba"
+    ],
+    "name:kab_x_variant":[
+        "Buga\u025ba"
     ],
     "name:nan_x_preferred":[
         "Bougaa"
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":421197481,
-    "wof:lastmodified":1566583498,
+    "wof:lastmodified":1690875528,
     "wof:name":"Bougaa",
     "wof:parent_id":85670845,
     "wof:placetype":"locality",

--- a/data/421/197/483/421197483.geojson
+++ b/data/421/197/483/421197483.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u0628\u0627\u0634\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u0628\u0627\u0634\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u0628\u0627\u0634\u0647"
     ],
@@ -50,6 +53,9 @@
     "name:nld_x_preferred":[
         "Barbacha"
     ],
+    "name:pol_x_preferred":[
+        "Barbasza"
+    ],
     "name:por_x_preferred":[
         "Barbacha"
     ],
@@ -70,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u67cf\u5df4\u6c99"
+    ],
+    "name:zul_x_preferred":[
+        "Barbacha"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -116,7 +125,7 @@
         }
     ],
     "wof:id":421197483,
-    "wof:lastmodified":1566583498,
+    "wof:lastmodified":1690875527,
     "wof:name":"Souk et Tleta",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/198/159/421198159.geojson
+++ b/data/421/198/159/421198159.geojson
@@ -22,8 +22,14 @@
     "name:als_x_preferred":[
         "Victor Hugo"
     ],
+    "name:alt_x_preferred":[
+        "\u0413\u044e\u0433\u043e"
+    ],
     "name:amh_x_preferred":[
         "\u126a\u12ad\u1276\u122d \u12a2\u12cd\u130e"
+    ],
+    "name:anp_x_preferred":[
+        "\u0935\u093f\u0915\u094d\u091f\u0930 \u0939\u094d\u092f\u0942\u0917\u094b"
     ],
     "name:ara_x_preferred":[
         "\u0641\u0643\u062a\u0648\u0631 \u0647\u0648\u063a\u0648"
@@ -31,11 +37,23 @@
     "name:arg_x_preferred":[
         "Victor Hugo"
     ],
+    "name:ary_x_preferred":[
+        "\u06a4\u064a\u0643\u0637\u0648\u0631 \u0647\u064a\u06ad\u0648"
+    ],
     "name:arz_x_preferred":[
         "\u0641\u064a\u0643\u062a\u0648\u0631 \u0647\u0648\u062c\u0648"
     ],
     "name:ast_x_preferred":[
         "Victor Hugo"
+    ],
+    "name:ava_x_preferred":[
+        "\u042e\u0433\u043e"
+    ],
+    "name:avk_x_preferred":[
+        "Victor Hugo"
+    ],
+    "name:awa_x_preferred":[
+        "\u092d\u093f\u0915\u094d\u091f\u0930 \u0939\u094d\u092f\u0942\u0917\u094b"
     ],
     "name:aym_x_preferred":[
         "Victor Hugo"
@@ -52,6 +70,9 @@
     "name:bar_x_preferred":[
         "Victor Hugo"
     ],
+    "name:bcl_x_preferred":[
+        "Victor Hugo"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u0456\u043a\u0442\u043e\u0440 \u0413\u044e\u0433\u043e"
     ],
@@ -60,6 +81,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09ad\u09bf\u0995\u09cd\u099f\u09b0 \u09b9\u09c1\u0997\u09cb"
+    ],
+    "name:bho_x_preferred":[
+        "\u0935\u093f\u0915\u094d\u091f\u0930 \u0939\u094d\u092f\u0942\u0917\u094b"
     ],
     "name:bis_x_preferred":[
         "Victor Hugo"
@@ -102,6 +126,12 @@
     ],
     "name:ckb_x_preferred":[
         "\u06a4\u06cc\u06a9\u062a\u06c6\u0631 \u06be\u0648\u06af\u06c6"
+    ],
+    "name:cor_x_preferred":[
+        "Victor Hugo"
+    ],
+    "name:crh_x_preferred":[
+        "Viktor H\u00fcgo"
     ],
     "name:cym_x_preferred":[
         "Victor Hugo"
@@ -173,6 +203,9 @@
         "Victor Hugo"
     ],
     "name:gsw_x_preferred":[
+        "Victor Hugo"
+    ],
+    "name:guw_x_preferred":[
         "Victor Hugo"
     ],
     "name:hak_x_preferred":[
@@ -379,6 +412,9 @@
     "name:pan_x_variant":[
         "\u0a35\u0a3f\u0a15\u0a1f\u0a30 \u0a39\u0a3f\u0a0a\u0a17\u0a4b"
     ],
+    "name:pap_x_preferred":[
+        "Victor Hugo"
+    ],
     "name:pcd_x_preferred":[
         "Victor Hugo"
     ],
@@ -439,6 +475,9 @@
     "name:sgs_x_preferred":[
         "Victor Hugo"
     ],
+    "name:shi_x_preferred":[
+        "Viktu\u1e5b Higu"
+    ],
     "name:sin_x_preferred":[
         "\u0dc0\u0dd2\u0d9a\u0dca\u0da7\u0dbb\u0dca \u0dc4\u0dd2\u0dba\u0dd4\u0d9c\u0ddd"
     ],
@@ -478,6 +517,9 @@
     "name:tel_x_preferred":[
         "\u0c35\u0c3f\u0c15\u0c4d\u0c1f\u0c30\u0c4d \u0c39\u0c4d\u0c2f\u0c42\u0c17\u0c4b"
     ],
+    "name:tgk_x_preferred":[
+        "\u0412\u0438\u043a\u0442\u043e\u0440 \u04b2\u0443\u0433\u0443"
+    ],
     "name:tgl_x_preferred":[
         "Victor Hugo"
     ],
@@ -509,6 +551,9 @@
         "G\u00fcgo Viktor"
     ],
     "name:vie_x_preferred":[
+        "Victor Hugo"
+    ],
+    "name:vls_x_preferred":[
         "Victor Hugo"
     ],
     "name:vol_x_preferred":[
@@ -592,7 +637,7 @@
         }
     ],
     "wof:id":421198159,
-    "wof:lastmodified":1566583494,
+    "wof:lastmodified":1690875522,
     "wof:name":"Victor Hugo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/198/645/421198645.geojson
+++ b/data/421/198/645/421198645.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u0633\u0628\u0627\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u0633\u0628\u0627\u0633"
+    ],
     "name:ceb_x_preferred":[
         "Besbes"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:ita_x_preferred":[
         "Besbes"
+    ],
+    "name:kab_x_preferred":[
+        "Lbesbas"
     ],
     "name:msa_x_preferred":[
         "Besbes"
@@ -111,7 +117,7 @@
         }
     ],
     "wof:id":421198645,
-    "wof:lastmodified":1566583494,
+    "wof:lastmodified":1690875523,
     "wof:name":"Besbes",
     "wof:parent_id":85670719,
     "wof:placetype":"locality",

--- a/data/421/198/657/421198657.geojson
+++ b/data/421/198/657/421198657.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0641\u064a\u0632\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0641\u064a\u0632\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0641\u06cc\u0632\u0641"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:kab_x_preferred":[
         "Sfisef"
+    ],
+    "name:kab_x_variant":[
+        "Sfizef"
     ],
     "name:msa_x_preferred":[
         "Sfissef"
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":421198657,
-    "wof:lastmodified":1566583495,
+    "wof:lastmodified":1690875523,
     "wof:name":"Sfizef",
     "wof:parent_id":85670691,
     "wof:placetype":"locality",

--- a/data/421/198/661/421198661.geojson
+++ b/data/421/198/661/421198661.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0635\u062f\u0648\u0642"
     ],
+    "name:arz_x_preferred":[
+        "\u0635\u062f\u0648\u0642"
+    ],
     "name:ceb_x_preferred":[
         "Seddouk"
     ],
@@ -56,6 +59,9 @@
     "name:swe_x_preferred":[
         "Seddouk"
     ],
+    "name:uzb_x_preferred":[
+        "Seddouk"
+    ],
     "name:vie_x_preferred":[
         "Seddouk"
     ],
@@ -64,6 +70,9 @@
     ],
     "name:zho_x_preferred":[
         "\u585e\u675c\u514b"
+    ],
+    "name:zul_x_preferred":[
+        "Seddouk"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -111,7 +120,7 @@
         }
     ],
     "wof:id":421198661,
-    "wof:lastmodified":1566583494,
+    "wof:lastmodified":1690875523,
     "wof:name":"Seddouk",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/198/997/421198997.geojson
+++ b/data/421/198/997/421198997.geojson
@@ -20,7 +20,13 @@
     "name:ara_x_preferred":[
         "\u0639\u0632\u0627\u0632\u0642\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u0632\u0627\u0632\u0642\u0647"
+    ],
     "name:bre_x_preferred":[
+        "Azazga"
+    ],
+    "name:cat_x_preferred":[
         "Azazga"
     ],
     "name:ceb_x_preferred":[
@@ -53,11 +59,17 @@
     "name:nld_x_preferred":[
         "Azazga"
     ],
+    "name:pol_x_preferred":[
+        "Azazga"
+    ],
     "name:por_x_preferred":[
         "Azazga"
     ],
     "name:ron_x_preferred":[
         "Azazga"
+    ],
+    "name:rus_x_preferred":[
+        "\u0410\u0437\u0430\u0437\u0433\u0430"
     ],
     "name:spa_x_preferred":[
         "Azazga"
@@ -76,6 +88,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u624e\u8332\u52a0"
+    ],
+    "name:zul_x_preferred":[
+        "Azazga"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -123,7 +138,7 @@
         }
     ],
     "wof:id":421198997,
-    "wof:lastmodified":1566583494,
+    "wof:lastmodified":1690875523,
     "wof:name":"Azazga",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/198/999/421198999.geojson
+++ b/data/421/198/999/421198999.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0642\u0628\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0642\u0628\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0642\u0628\u0648"
     ],
@@ -31,6 +34,9 @@
     ],
     "name:deu_x_preferred":[
         "Akbou"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03ba\u03bc\u03c0\u03bf\u03cd"
     ],
     "name:eng_x_preferred":[
         "Akbou"
@@ -56,14 +62,23 @@
     "name:nld_x_preferred":[
         "Akbou"
     ],
+    "name:pol_x_preferred":[
+        "Akbu"
+    ],
     "name:por_x_preferred":[
         "Akbou"
     ],
     "name:ron_x_preferred":[
         "Akbou"
     ],
+    "name:swa_x_preferred":[
+        "Akbou"
+    ],
     "name:swe_x_preferred":[
         "Akbou"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0410\u049b\u0431\u04ef"
     ],
     "name:und_x_variant":[
         "Metz"
@@ -76,6 +91,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u514b\u5e03"
+    ],
+    "name:zul_x_preferred":[
+        "Akbou"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -123,7 +141,7 @@
         }
     ],
     "wof:id":421198999,
-    "wof:lastmodified":1566583494,
+    "wof:lastmodified":1690875523,
     "wof:name":"Akbou",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/199/003/421199003.geojson
+++ b/data/421/199/003/421199003.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u064a\u0631\u064a\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u064a\u0631\u064a\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u06cc\u0631\u06cc\u0646"
     ],
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421199003,
-    "wof:lastmodified":1566583499,
+    "wof:lastmodified":1690875528,
     "wof:name":"Birine",
     "wof:parent_id":85670833,
     "wof:placetype":"locality",

--- a/data/421/199/005/421199005.geojson
+++ b/data/421/199/005/421199005.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0645\u0633\u0639\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0633\u0639\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0633\u0639\u062f"
+    ],
+    "name:aze_x_preferred":[
+        "M\u0259s\u0259d"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09c7\u09b8\u09b8\u09be\u09a6"
@@ -31,6 +37,9 @@
     ],
     "name:dan_x_preferred":[
         "Messa\u00e2d"
+    ],
+    "name:deu_x_preferred":[
+        "Messaad"
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b5\u03c3\u03b1\u03ac\u03bd\u03c4"
@@ -64,6 +73,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30e1\u30b7\u30e3\u30fc\u30aa\u30fc\u30c9"
+    ],
+    "name:kab_x_preferred":[
+        "Mes\u025bed"
     ],
     "name:kan_x_preferred":[
         "\u0cae\u0cc6\u0cb8\u0ccd\u0cb8\u0cbe\u0ca6\u0ccd"
@@ -109,6 +121,12 @@
     ],
     "name:spa_x_preferred":[
         "Messa\u00e2d"
+    ],
+    "name:spa_x_variant":[
+        "Messaad"
+    ],
+    "name:swa_x_preferred":[
+        "Messaad"
     ],
     "name:swe_x_preferred":[
         "Messaad"
@@ -186,7 +204,7 @@
         }
     ],
     "wof:id":421199005,
-    "wof:lastmodified":1566583499,
+    "wof:lastmodified":1690875528,
     "wof:name":"Messaad",
     "wof:parent_id":85670833,
     "wof:placetype":"locality",

--- a/data/421/199/007/421199007.geojson
+++ b/data/421/199/007/421199007.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u0642"
     ],
+    "name:arq_x_preferred":[
+        "\u0633\u064a\u06a8"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0642"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u0642"
     ],
@@ -52,6 +58,9 @@
     ],
     "name:kab_x_preferred":[
         "Sigg"
+    ],
+    "name:kab_x_variant":[
+        "Sig"
     ],
     "name:msa_x_preferred":[
         "Sig"
@@ -138,7 +147,7 @@
         }
     ],
     "wof:id":421199007,
-    "wof:lastmodified":1566583499,
+    "wof:lastmodified":1690875528,
     "wof:name":"Sig",
     "wof:parent_id":85670785,
     "wof:placetype":"locality",

--- a/data/421/200/183/421200183.geojson
+++ b/data/421/200/183/421200183.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0645\u064a\u0632\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0645\u064a\u0632\u0648\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0645\u06cc\u0632\u0648\u0631"
     ],
@@ -50,6 +53,9 @@
     "name:nld_x_preferred":[
         "Amizour"
     ],
+    "name:pol_x_preferred":[
+        "Amizur"
+    ],
     "name:por_x_preferred":[
         "Amizour"
     ],
@@ -65,6 +71,9 @@
     "name:und_x_variant":[
         "Colmar"
     ],
+    "name:uzb_x_preferred":[
+        "Amizour"
+    ],
     "name:vie_x_preferred":[
         "Amizour"
     ],
@@ -73,6 +82,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u7c73\u7956\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Amizour"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -120,7 +132,7 @@
         }
     ],
     "wof:id":421200183,
-    "wof:lastmodified":1566583500,
+    "wof:lastmodified":1690875530,
     "wof:name":"Amizour",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/421/200/237/421200237.geojson
+++ b/data/421/200/237/421200237.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u062f\u0648\u0634 \u0645\u0631\u0627\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u062f\u0648\u0634 \u0645\u0631\u0627\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u06cc\u062f\u0648\u0634 \u0645\u0631\u0627\u062f"
     ],
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421200237,
-    "wof:lastmodified":1566583500,
+    "wof:lastmodified":1690875530,
     "wof:name":"Didouche Mourad",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",

--- a/data/421/200/239/421200239.geojson
+++ b/data/421/200/239/421200239.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062d\u0645\u0627\u0645 \u0628\u0648\u062d\u062c\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u0645\u0627\u0645 \u0628\u0648\u062d\u062c\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u062d\u0645\u0627\u0645 \u0628\u0648\u062d\u062c\u0631"
     ],
@@ -41,6 +44,9 @@
     "name:kab_x_preferred":[
         "\u1e24emmam Bu\u1e25jer"
     ],
+    "name:kab_x_variant":[
+        "\u1e24emmam Bu\u1e25\u01e7er"
+    ],
     "name:msa_x_preferred":[
         "Hammam Bouhadjar"
     ],
@@ -49,6 +55,9 @@
     ],
     "name:nld_x_preferred":[
         "Hammam Bouhadjar"
+    ],
+    "name:pol_x_preferred":[
+        "Hammam Bou Hadjar"
     ],
     "name:por_x_preferred":[
         "Hammam Bou Hadjar"
@@ -67,6 +76,9 @@
     ],
     "name:und_x_variant":[
         "Hommam Bou Hadjar"
+    ],
+    "name:uzb_x_preferred":[
+        "Hammam Bu Hadjar"
     ],
     "name:vie_x_preferred":[
         "Hammam Bouhadjar"
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":421200239,
-    "wof:lastmodified":1566583499,
+    "wof:lastmodified":1690875530,
     "wof:name":"Hammam Bou Hadjar",
     "wof:parent_id":85670683,
     "wof:placetype":"locality",

--- a/data/421/200/241/421200241.geojson
+++ b/data/421/200/241/421200241.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062d\u0646\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u0646\u0627\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062d\u0646\u0627\u06cc\u0647"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:kab_x_preferred":[
         "Hennaya"
+    ],
+    "name:kab_x_variant":[
+        "Le\u1e25naya"
     ],
     "name:msa_x_preferred":[
         "Hennaya"
@@ -71,10 +77,16 @@
     "name:und_x_variant":[
         "Eug\u00e9ne-\u00c9tienne Hennaya"
     ],
+    "name:uzb_x_preferred":[
+        "Hennaya"
+    ],
     "name:vie_x_preferred":[
         "Hennaya"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Hennaya"
+    ],
+    "name:zul_x_preferred":[
         "Hennaya"
     ],
     "qs:gn_country":"DZ",
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":421200241,
-    "wof:lastmodified":1566583499,
+    "wof:lastmodified":1690875529,
     "wof:name":"Hennaya",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/421/200/245/421200245.geojson
+++ b/data/421/200/245/421200245.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0631\u0648\u064a\u0633\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u0648\u064a\u0633\u0627\u062a"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0648\u06cc\u0633\u0627\u062a"
+    ],
+    "name:aze_x_preferred":[
+        "Ruysat"
     ],
     "name:ceb_x_preferred":[
         "Rouissat"
@@ -37,6 +43,9 @@
     ],
     "name:ita_x_preferred":[
         "Rouissat"
+    ],
+    "name:kab_x_preferred":[
+        "Rwisat"
     ],
     "name:msa_x_preferred":[
         "Rouissat"
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":421200245,
-    "wof:lastmodified":1566583499,
+    "wof:lastmodified":1690875529,
     "wof:name":"Rouissat",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",

--- a/data/421/200/247/421200247.geojson
+++ b/data/421/200/247/421200247.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0632\u064a \u063a\u0646\u064a\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0632\u0649 \u063a\u0646\u064a\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0632\u06cc \u063a\u0646\u06cc\u0641"
     ],
@@ -62,6 +65,9 @@
     "name:swe_x_preferred":[
         "Tizi Gheniff"
     ],
+    "name:uzb_x_preferred":[
+        "Tizi Ghenif"
+    ],
     "name:vie_x_preferred":[
         "Tizi-Ghenif"
     ],
@@ -70,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u63d0\u6fdf\u84cb\u5c3c\u592b"
+    ],
+    "name:zul_x_preferred":[
+        "Tizi Ghenif"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":421200247,
-    "wof:lastmodified":1566583499,
+    "wof:lastmodified":1690875529,
     "wof:name":"Tizi Gheniff",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/200/249/421200249.geojson
+++ b/data/421/200/249/421200249.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0631\u0645\u062a\u064a\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0631\u0645\u062a\u064a\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0631\u0645\u062a\u06cc\u0646"
     ],
@@ -59,6 +62,9 @@
     "name:swe_x_preferred":[
         "Tirmitine"
     ],
+    "name:uzb_x_preferred":[
+        "Tirmitin"
+    ],
     "name:vie_x_preferred":[
         "Tirmitine"
     ],
@@ -67,6 +73,9 @@
     ],
     "name:zho_x_preferred":[
         "\u63d0\u723e\u7c73\u4e01"
+    ],
+    "name:zul_x_preferred":[
+        "Tirmitine"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":421200249,
-    "wof:lastmodified":1566583499,
+    "wof:lastmodified":1690875529,
     "wof:name":"Tirmitine",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/421/202/325/421202325.geojson
+++ b/data/421/202/325/421202325.geojson
@@ -20,14 +20,38 @@
     "name:ara_x_preferred":[
         "\u0632\u0631\u0627\u0644\u062f\u0629"
     ],
+    "name:arq_x_preferred":[
+        "\u0632\u0631\u0627\u0644\u062f\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0632\u0631\u0627\u0644\u062f\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0632\u0631\u0627\u0644\u062f\u0627"
+    ],
+    "name:aze_x_preferred":[
+        "Zeralda"
+    ],
+    "name:bel_x_preferred":[
+        "\u0417\u0435\u0440\u0430\u043b\u044c\u0434\u0430"
     ],
     "name:ceb_x_preferred":[
         "Zeralda"
     ],
+    "name:dan_x_preferred":[
+        "Z\u00e9ralda"
+    ],
+    "name:deu_x_preferred":[
+        "Zeralda"
+    ],
+    "name:ell_x_preferred":[
+        "\u0396\u03b5\u03c1\u03ac\u03bb\u03bd\u03c4\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Z\u00e9ralda"
+    ],
+    "name:eng_x_variant":[
+        "Zeralda"
     ],
     "name:fas_x_preferred":[
         "\u0632\u0631\u0627\u0644\u062f\u0627"
@@ -35,11 +59,23 @@
     "name:fra_x_preferred":[
         "Z\u00e9ralda"
     ],
+    "name:heb_x_preferred":[
+        "\u05d6\u05e8\u05d0\u05dc\u05d3\u05d4"
+    ],
     "name:ita_x_preferred":[
         "Z\u00e9ralda"
     ],
+    "name:jpn_x_preferred":[
+        "\u30bc\u30e9\u30eb\u30c0"
+    ],
     "name:kab_x_preferred":[
         "Ziralda"
+    ],
+    "name:kor_x_preferred":[
+        "\uc81c\ub784\ub2e4"
+    ],
+    "name:kur_x_preferred":[
+        "Zeralda"
     ],
     "name:msa_x_preferred":[
         "Zeralda"
@@ -48,6 +84,12 @@
         "Z\u00e9ralda"
     ],
     "name:nld_x_preferred":[
+        "Z\u00e9ralda"
+    ],
+    "name:nno_x_preferred":[
+        "Z\u00e9ralda"
+    ],
+    "name:nob_x_preferred":[
         "Z\u00e9ralda"
     ],
     "name:por_x_preferred":[
@@ -59,11 +101,20 @@
     "name:ron_x_variant":[
         "Zeralda"
     ],
+    "name:sco_x_preferred":[
+        "Zeralda"
+    ],
     "name:spa_x_preferred":[
         "Z\u00e9ralda"
     ],
     "name:swe_x_preferred":[
         "Zeralda"
+    ],
+    "name:tur_x_preferred":[
+        "Zeralide"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0417\u0435\u0440\u0430\u043b\u044c\u0434\u0430"
     ],
     "name:urd_x_preferred":[
         "\u0632\u0631\u0627\u0644\u062f\u06c1"
@@ -117,7 +168,7 @@
         }
     ],
     "wof:id":421202325,
-    "wof:lastmodified":1566583487,
+    "wof:lastmodified":1690875514,
     "wof:name":"Zeralda",
     "wof:parent_id":85670771,
     "wof:placetype":"locality",

--- a/data/421/202/759/421202759.geojson
+++ b/data/421/202/759/421202759.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0633\u0639\u0627\u062f\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0633\u0639\u0627\u062f\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648 \u0633\u0639\u062f\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Bu-Sad\u0259"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09cb \u09b8\u09be\u09a6\u09be"
@@ -31,6 +37,9 @@
     ],
     "name:dan_x_preferred":[
         "Bou Saada"
+    ],
+    "name:deu_x_preferred":[
+        "Bou Sa\u00e2da"
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bf\u03c5 \u03a3\u03b1\u03ac\u03bd\u03c4\u03b1"
@@ -122,6 +131,9 @@
     "name:spa_x_preferred":[
         "Bou Sa\u00e2da"
     ],
+    "name:swa_x_preferred":[
+        "Bou Sa\u00e2da"
+    ],
     "name:swe_x_preferred":[
         "Bou Sa\u00e2da"
     ],
@@ -200,7 +212,7 @@
         }
     ],
     "wof:id":421202759,
-    "wof:lastmodified":1566583487,
+    "wof:lastmodified":1690875514,
     "wof:name":"Bou Saada",
     "wof:parent_id":85670841,
     "wof:placetype":"locality",

--- a/data/421/203/675/421203675.geojson
+++ b/data/421/203/675/421203675.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0639\u0628\u064a\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0639\u0628\u064a\u062f"
+    ],
+    "name:ceb_x_preferred":[
+        "'A\u00efn Abid"
+    ],
     "name:eng_x_preferred":[
         "A\u00efn Abid"
+    ],
+    "name:fas_x_preferred":[
+        "\u0639\u06cc\u0646 \u0639\u0628\u06cc\u062f"
     ],
     "name:fra_x_preferred":[
         "A\u00efn Abid"
@@ -49,6 +58,9 @@
     ],
     "name:spa_x_preferred":[
         "A\u00efn Abid"
+    ],
+    "name:swe_x_preferred":[
+        "'A\u00efn Abid"
     ],
     "name:und_x_variant":[
         "A\u00efne Abid"
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":421203675,
-    "wof:lastmodified":1566583486,
+    "wof:lastmodified":1690875514,
     "wof:name":"'Ain Abid",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",

--- a/data/421/205/381/421205381.geojson
+++ b/data/421/205/381/421205381.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u0630\u0647\u0628"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u0630\u0647\u0628"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0630\u0647\u0628"
+    ],
+    "name:ceb_x_preferred":[
+        "'A\u00efn Deheb"
     ],
     "name:eng_x_preferred":[
         "A\u00efn Deheb"
@@ -56,6 +62,9 @@
     "name:spa_x_preferred":[
         "A\u00efn Deheb"
     ],
+    "name:swe_x_preferred":[
+        "'A\u00efn Deheb"
+    ],
     "name:und_x_variant":[
         "El Ousseukh"
     ],
@@ -64,6 +73,9 @@
     ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u4ee3\u6d77\u535c"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Deheb"
     ],
     "qs:gn_country":"DZ",
     "qs:gn_fcode":"PPL",
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421205381,
-    "wof:lastmodified":1566583488,
+    "wof:lastmodified":1690875516,
     "wof:name":"'Ain Deheb",
     "wof:parent_id":85670801,
     "wof:placetype":"locality",

--- a/data/421/205/383/421205383.geojson
+++ b/data/421/205/383/421205383.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0646 \u0645\u0647\u064a\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646 \u0645\u0647\u064a\u062f\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646 \u0645\u0647\u06cc\u062f\u06cc"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:deu_x_preferred":[
         "Ben Mehdi"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03bd \u039c\u03b5\u03c7\u03bd\u03c4\u03af"
     ],
     "name:eng_x_preferred":[
         "Ben Mehdi"
@@ -120,7 +126,7 @@
         }
     ],
     "wof:id":421205383,
-    "wof:lastmodified":1566583487,
+    "wof:lastmodified":1690875515,
     "wof:name":"Ben Mehidi",
     "wof:parent_id":85670719,
     "wof:placetype":"locality",

--- a/data/421/205/385/421205385.geojson
+++ b/data/421/205/385/421205385.geojson
@@ -20,17 +20,26 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0641\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0641\u0647"
+    ],
     "name:ceb_x_preferred":[
         "Chiffa"
     ],
     "name:eng_x_preferred":[
         "Chiffa"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0644\u0634\u0641\u0647"
+    ],
     "name:fra_x_preferred":[
         "Chiffa"
     ],
     "name:ita_x_preferred":[
         "Chiffa"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c1\u30d5\u30a1"
     ],
     "name:msa_x_preferred":[
         "Chiffa"
@@ -63,6 +72,9 @@
         "Chiffa"
     ],
     "name:zho_min_nan_x_preferred":[
+        "Chiffa"
+    ],
+    "name:zul_x_preferred":[
         "Chiffa"
     ],
     "qs:gn_country":"DZ",
@@ -111,7 +123,7 @@
         }
     ],
     "wof:id":421205385,
-    "wof:lastmodified":1566583487,
+    "wof:lastmodified":1690875515,
     "wof:name":"Chiffa",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/421/205/387/421205387.geojson
+++ b/data/421/205/387/421205387.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0647\u064a\u0644\u064a\u0648\u0628\u0648\u0644\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0647\u064a\u0644\u064a\u0648\u0628\u0648\u0644\u064a\u0633"
+    ],
     "name:azb_x_preferred":[
         "\u0647\u06cc\u0644\u06cc\u0648\u0628\u0648\u0644\u06cc\u0633"
     ],
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421205387,
-    "wof:lastmodified":1566583488,
+    "wof:lastmodified":1690875515,
     "wof:name":"Heliopolis",
     "wof:parent_id":85670857,
     "wof:placetype":"locality",

--- a/data/421/205/389/421205389.geojson
+++ b/data/421/205/389/421205389.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u062d\u0627\u0633\u064a \u0645\u0633\u0639\u0648\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u062d\u0627\u0633\u0649 \u0645\u0633\u0639\u0648\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u062d\u0627\u0633\u06cc \u0645\u0633\u0639\u0648\u062f"
+    ],
+    "name:aze_x_preferred":[
+        "Hasi-M\u0259sud"
     ],
     "name:ben_x_preferred":[
         "\u09b9\u09be\u09b8\u09b8\u09bf \u09ae\u09c7\u09b8\u09b8\u09be\u0989\u09a6"
@@ -37,6 +43,9 @@
     ],
     "name:deu_x_preferred":[
         "Hassi Messaoud"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a7\u03ac\u03c3\u03b9 \u039c\u03b5\u03c3\u03b1\u03bf\u03cd\u03bd\u03c4"
     ],
     "name:eng_x_preferred":[
         "Hassi Messaoud"
@@ -65,6 +74,9 @@
     "name:jpn_x_preferred":[
         "\u30cf\u30b7\u30e1\u30b5\u30a6\u30c9"
     ],
+    "name:kab_x_preferred":[
+        "\u1e24asi Mes\u025bud"
+    ],
     "name:kor_x_preferred":[
         "\ud558\uc2dc\uba54\uc0ac\uc6b0\ub4dc"
     ],
@@ -76,6 +88,9 @@
     ],
     "name:nld_x_preferred":[
         "Hassi Messaoud"
+    ],
+    "name:nob_x_preferred":[
+        "Hassi-Messaoud"
     ],
     "name:pol_x_preferred":[
         "Hassi Messaoud"
@@ -257,7 +272,7 @@
         }
     ],
     "wof:id":421205389,
-    "wof:lastmodified":1636501719,
+    "wof:lastmodified":1690875515,
     "wof:name":"Hassi Messaoud",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",

--- a/data/421/205/395/421205395.geojson
+++ b/data/421/205/395/421205395.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0631\u0642\u064a\u0628\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u0642\u064a\u0628\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0642\u06cc\u0628\u0647"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Reguiba"
+    ],
+    "name:kab_x_preferred":[
+        "Rrgiba"
     ],
     "name:msa_x_preferred":[
         "Reguiba"
@@ -111,7 +117,7 @@
         }
     ],
     "wof:id":421205395,
-    "wof:lastmodified":1566583488,
+    "wof:lastmodified":1690875515,
     "wof:name":"Reguiba",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",

--- a/data/856/324/51/85632451.geojson
+++ b/data/856/324/51/85632451.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":7.0,
     "mz:min_zoom":2.0,
+    "name:abk_x_preferred":[
+        "\u0410\u043b\u0436\u0438\u0440"
+    ],
     "name:ace_x_preferred":[
         "Aljazair"
     ],
@@ -52,8 +55,14 @@
     "name:amh_x_preferred":[
         "\u12a0\u120d\u1304\u122a\u12eb"
     ],
+    "name:ami_x_preferred":[
+        "Algeria"
+    ],
     "name:ang_x_preferred":[
         "Algeria"
+    ],
+    "name:anp_x_preferred":[
+        "\u0905\u0932\u094d\u091c\u0940\u0930\u093f\u092f\u093e"
     ],
     "name:ara_x_preferred":[
         "\u0627\u0644\u062c\u0632\u0627\u0626\u0631"
@@ -75,6 +84,9 @@
     "name:ary_x_preferred":[
         "\u0644\u062c\u0627\u0632\u0627\u0626\u064a\u0631"
     ],
+    "name:ary_x_variant":[
+        "\u062c\u0632\u0627\u064a\u0631"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u062c\u0632\u0627\u064a\u0631"
     ],
@@ -83,6 +95,9 @@
     ],
     "name:ast_x_preferred":[
         "Arxelia"
+    ],
+    "name:avk_x_preferred":[
+        "Jazaira"
     ],
     "name:aym_x_preferred":[
         "Alhirya"
@@ -131,6 +146,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0905\u0932\u094d\u091c\u0940\u0930\u093f\u092f\u093e"
+    ],
+    "name:bis_x_preferred":[
+        "Aljiria"
     ],
     "name:bjn_x_preferred":[
         "Aljajair"
@@ -202,6 +220,9 @@
     "name:cym_x_preferred":[
         "Algeria"
     ],
+    "name:dag_x_preferred":[
+        "Algeria"
+    ],
     "name:dan_x_preferred":[
         "Algeriet"
     ],
@@ -216,6 +237,9 @@
     ],
     "name:deu_x_variant":[
         "Demokratische Volksrepublik Algerien"
+    ],
+    "name:din_x_preferred":[
+        "Algeria"
     ],
     "name:diq_x_preferred":[
         "Cezayir"
@@ -336,6 +360,12 @@
     "name:gom_x_preferred":[
         "\u0906\u0932\u094d\u091c\u0947\u0930\u093f\u092f\u093e"
     ],
+    "name:gor_x_preferred":[
+        "Aljazair"
+    ],
+    "name:gpe_x_preferred":[
+        "Algeria"
+    ],
     "name:grn_x_preferred":[
         "Arh\u00e9lia"
     ],
@@ -350,6 +380,9 @@
     ],
     "name:guj_x_variant":[
         "\u0a85\u0ab2\u0a9c\u0ac0\u0ab0\u0abf\u0aaf\u0abe"
+    ],
+    "name:gur_x_preferred":[
+        "Algeria"
     ],
     "name:hak_x_preferred":[
         "Algeria"
@@ -488,6 +521,9 @@
     "name:kir_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
     ],
+    "name:kom_x_preferred":[
+        "\u0410\u043b\u0436\u0438\u0440"
+    ],
     "name:kon_x_preferred":[
         "Algeria"
     ],
@@ -509,6 +545,9 @@
     ],
     "name:lao_x_preferred":[
         "\u0ec1\u0ead\u0ea5\u0e88\u0eb4\u0ec0\u0ea5\u0e8d"
+    ],
+    "name:lao_x_variant":[
+        "\u0e9b\u0eb0\u0ec0\u0e97\u0e94\u0ec1\u0ead\u0ea5\u0e88\u0eb5\u0ec0\u0ea3\u0e8d"
     ],
     "name:lat_x_preferred":[
         "Algerium"
@@ -540,8 +579,14 @@
     "name:lit_x_preferred":[
         "Al\u017eyras"
     ],
+    "name:lld_x_preferred":[
+        "Algeria"
+    ],
     "name:lmo_x_preferred":[
         "Algeria"
+    ],
+    "name:ltg_x_preferred":[
+        "Al\u017eireja"
     ],
     "name:ltz_x_preferred":[
         "Algerien"
@@ -558,6 +603,9 @@
     "name:lzh_x_preferred":[
         "\u963f\u723e\u53ca\u5229\u4e9e"
     ],
+    "name:mad_x_preferred":[
+        "Aljazair"
+    ],
     "name:mai_x_preferred":[
         "\u0905\u0932\u094d\u091c\u0947\u0930\u093f\u092f\u093e"
     ],
@@ -572,6 +620,9 @@
     ],
     "name:mdf_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
+    ],
+    "name:mdf_x_variant":[
+        "\u0410\u043b\u0436\u0438\u0440\u0438\u044f"
     ],
     "name:mhr_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
@@ -591,8 +642,14 @@
     "name:mlt_x_preferred":[
         "Al\u0121erija"
     ],
+    "name:mni_x_preferred":[
+        "\uabd1\uabdc\uabd6\uabe6\uabd4\uabe4\uabcc\uabe5"
+    ],
     "name:mon_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
+    ],
+    "name:mos_x_preferred":[
+        "Algeria"
     ],
     "name:mri_x_preferred":[
         "Aratiria"
@@ -605,6 +662,9 @@
     ],
     "name:msa_x_variant":[
         "Aljazair"
+    ],
+    "name:mwl_x_preferred":[
+        "Arg\u00e9lia"
     ],
     "name:mya_x_preferred":[
         "\u1021\u101a\u103a\u101c\u103a\u1002\u103b\u102e\u1038\u101b\u102e\u1038\u101a\u102c\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
@@ -687,6 +747,12 @@
     "name:pap_x_preferred":[
         "Algeria"
     ],
+    "name:pcd_x_preferred":[
+        "Alg\u00e9rie"
+    ],
+    "name:pcm_x_preferred":[
+        "Aljiria"
+    ],
     "name:pdc_x_preferred":[
         "Altschieri"
     ],
@@ -763,6 +829,12 @@
     "name:sgs_x_preferred":[
         "Al\u017e\u012brs"
     ],
+    "name:shi_x_preferred":[
+        "Dzayr"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1022\u1084\u1038\u1075\u103b\u102e\u1038\u101b\u102e\u1038\u101a\u1083\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0d87\u0dbd\u0dca\u0da2\u0dd3\u0dbb\u0dd2\u0dba\u0dcf\u0dc0"
     ],
@@ -775,7 +847,13 @@
     "name:sme_x_preferred":[
         "Algeria"
     ],
+    "name:smn_x_preferred":[
+        "Algeria"
+    ],
     "name:smo_x_preferred":[
+        "Algeria"
+    ],
+    "name:sms_x_preferred":[
         "Algeria"
     ],
     "name:sna_x_preferred":[
@@ -832,6 +910,9 @@
     "name:swe_x_preferred":[
         "Algeriet"
     ],
+    "name:syl_x_preferred":[
+        "\ua800\ua81f\ua80e\ua826\ua81e\ua824\ua800"
+    ],
     "name:szl_x_preferred":[
         "Algeryjo"
     ],
@@ -849,6 +930,9 @@
     ],
     "name:tat_x_preferred":[
         "\u04d8\u043b\u0497\u04d9\u0437\u0430\u0438\u0440"
+    ],
+    "name:tay_x_preferred":[
+        "Algeria"
     ],
     "name:tel_x_preferred":[
         "\u0c05\u0c32\u0c4d\u0c1c\u0c40\u0c30\u0c3f\u0c2f\u0c3e"
@@ -874,8 +958,14 @@
     "name:tir_x_variant":[
         "\u12a0\u120d\u1300\u122a\u12eb"
     ],
+    "name:tok_x_preferred":[
+        "ma Sasali"
+    ],
     "name:ton_x_preferred":[
         "\u02bbAisilia"
+    ],
+    "name:trv_x_preferred":[
+        "Algeria"
     ],
     "name:tso_x_preferred":[
         "Algeriya"
@@ -883,11 +973,17 @@
     "name:tuk_x_preferred":[
         "Al\u017eir"
     ],
+    "name:tum_x_preferred":[
+        "Algeria"
+    ],
     "name:tur_x_preferred":[
         "Cezayir"
     ],
     "name:twi_x_preferred":[
         "Algeria"
+    ],
+    "name:tzm_x_preferred":[
+        "\u2d37\u2d63\u2d30\u2d62\u2d54"
     ],
     "name:udm_x_preferred":[
         "\u0410\u043b\u0436\u0438\u0440"
@@ -919,6 +1015,9 @@
     ],
     "name:vec_x_preferred":[
         "Algeria"
+    ],
+    "name:vec_x_variant":[
+        "Alzeria"
     ],
     "name:vep_x_preferred":[
         "Al\u017eir"
@@ -1229,7 +1328,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1617827559,
+    "wof:lastmodified":1690875502,
     "wof:name":"Algeria",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/706/77/85670677.geojson
+++ b/data/856/706/77/85670677.geojson
@@ -38,6 +38,9 @@
     "name:ast_x_preferred":[
         "Provincia d'Adrar"
     ],
+    "name:ast_x_variant":[
+        "provincia d'Adrar"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u0631\u0627\u0631 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
@@ -68,6 +71,12 @@
     "name:ces_x_preferred":[
         "Adrar"
     ],
+    "name:che_x_preferred":[
+        "\u0410\u0434\u0440\u0430\u0440"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Adrar"
+    ],
     "name:dan_x_preferred":[
         "Adrar"
     ],
@@ -79,6 +88,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0391\u03bd\u03c4\u03c1\u03ac\u03c1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0391\u03bd\u03c4\u03c1\u03ac\u03c1"
     ],
     "name:eng_x_preferred":[
         "Adrar"
@@ -109,6 +121,12 @@
     ],
     "name:fra_x_variant":[
         "wilaya d'Adrar"
+    ],
+    "name:frr_x_preferred":[
+        "Adrar"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Adrar"
     ],
     "name:glg_x_preferred":[
         "Adrar"
@@ -248,6 +266,9 @@
     "name:tha_x_preferred":[
         "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e31\u0e14\u0e23\u0e32\u0e23\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e2d\u0e31\u0e14\u0e23\u0e2d\u0e23"
+    ],
     "name:tur_x_preferred":[
         "Adrar"
     ],
@@ -272,6 +293,9 @@
     "name:war_x_preferred":[
         "Adrar"
     ],
+    "name:wuu_x_preferred":[
+        "\u963f\u5fb7\u62c9\u5c14\u7701"
+    ],
     "name:xmf_x_preferred":[
         "\u10d0\u10d3\u10e0\u10d0\u10e0\u10d8\u10e8 \u10d5\u10d8\u10da\u10d0\u10d8\u10d4\u10d7\u10d8"
     ],
@@ -280,6 +304,9 @@
     ],
     "name:zho_x_variant":[
         "\u963f\u5fb7\u62c9\u723e\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Adrar Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -401,7 +428,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501712,
+    "wof:lastmodified":1690875490,
     "wof:name":"Adrar",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/83/85670683.geojson
+++ b/data/856/706/83/85670683.geojson
@@ -37,7 +37,11 @@
         "\u0639\u064a\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
     ],
     "name:ara_x_variant":[
-        "'A\u00efn Temouchent"
+        "'A\u00efn Temouchent",
+        "\u0648\u0644\u0627\u064a\u0629 \u0639\u064a\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
+    ],
+    "name:ast_x_preferred":[
+        "provincia d'A\u00efn T\u00e9mouchent"
     ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u062a\u0645\u0648\u0634\u0646\u062a \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
@@ -63,6 +67,9 @@
     "name:ceb_x_preferred":[
         "Wilaya de A\u00efn Temouchent"
     ],
+    "name:cym_x_preferred":[
+        "Talaith A\u00efn T\u00e9mouchent"
+    ],
     "name:dan_x_preferred":[
         "A\u00efn T\u00e9mouchent"
     ],
@@ -72,6 +79,9 @@
     "name:ell_x_preferred":[
         "\u0391\u0390\u03bd \u03a4\u03b5\u03bc\u03bf\u03c5\u03c7\u03ad\u03bd\u03c4"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0391\u0390\u03bd \u03a4\u03b5\u03bc\u03bf\u03c5\u03c7\u03ad\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "A\u00efn T\u00e9mouchent"
     ],
@@ -80,6 +90,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Ajn Temu\u015dent"
+    ],
+    "name:eus_x_preferred":[
+        "Ain Temouchenteko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0639\u06cc\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
@@ -92,6 +105,12 @@
     ],
     "name:fra_x_variant":[
         "A\u00efn T\u00e9mouchent"
+    ],
+    "name:frr_x_preferred":[
+        "A\u00efn T\u00e9mouchent"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige A\u00efn T\u00e9mouchent"
     ],
     "name:glg_x_preferred":[
         "Provincia de A\u00efn T\u00e9mouchent"
@@ -213,14 +232,23 @@
     "name:urd_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u0639\u06cc\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
     ],
+    "name:uzb_x_preferred":[
+        "A\u00efn T\u00e9mouchent viloyati"
+    ],
     "name:vie_x_preferred":[
         "A\u00efn T\u00e9mouchent"
     ],
     "name:war_x_preferred":[
         "A\u00efn T\u00e9mouchent"
     ],
+    "name:wuu_x_preferred":[
+        "\u827e\u56e0\u6cf0\u7a46\u5c1a\u7279\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u6cf0\u7a46\u5c1a\u7279\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn T\u00e9mouchent Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -343,7 +371,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807360,
+    "wof:lastmodified":1690875490,
     "wof:name":"A\u00efn T\u00e9mouchent",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/89/85670689.geojson
+++ b/data/856/706/89/85670689.geojson
@@ -41,8 +41,14 @@
     "name:ast_x_preferred":[
         "Provincia d'Or\u00e1n"
     ],
+    "name:ast_x_variant":[
+        "provincia d'Or\u00e1n"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0647\u0631\u0627\u0646 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "V\u0259hran vilay\u0259ti"
     ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u0410\u0440\u0430\u043d"
@@ -59,6 +65,12 @@
     "name:ceb_x_preferred":[
         "Oran"
     ],
+    "name:ces_x_preferred":[
+        "Provincie Vahr\u00e1n"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Oran"
+    ],
     "name:dan_x_preferred":[
         "Oran"
     ],
@@ -68,6 +80,9 @@
     "name:ell_x_preferred":[
         "\u039f\u03c1\u03ac\u03bd"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039f\u03c1\u03ac\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Oran"
     ],
@@ -76,6 +91,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Oran"
+    ],
+    "name:eus_x_preferred":[
+        "Orango probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0648\u0647\u0631\u0627\u0646"
@@ -88,6 +106,9 @@
     ],
     "name:fra_x_variant":[
         "Oran"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Oran"
     ],
     "name:glg_x_preferred":[
         "Provincia de Or\u00e1n"
@@ -103,6 +124,9 @@
     ],
     "name:hun_x_preferred":[
         "Oran"
+    ],
+    "name:hye_x_preferred":[
+        "\u0555\u0580\u0561\u0576 \u0576\u0561\u0570\u0561\u0576\u0563"
     ],
     "name:ina_x_preferred":[
         "Provincia Oran"
@@ -218,6 +242,9 @@
     "name:urd_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u0648\u06be\u0631\u0627\u0646"
     ],
+    "name:uzb_x_preferred":[
+        "Vahron viloyati"
+    ],
     "name:vie_x_preferred":[
         "Oran"
     ],
@@ -226,6 +253,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5965\u5170\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Oran Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -346,7 +376,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501712,
+    "wof:lastmodified":1690875489,
     "wof:name":"Oran",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/91/85670691.geojson
+++ b/data/856/706/91/85670691.geojson
@@ -53,6 +53,9 @@
     "name:cat_x_preferred":[
         "Prov\u00edncia de Sidi Bel Abbes"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Sidi Bel Abb\u00e8s"
+    ],
     "name:dan_x_preferred":[
         "Sidi Bel Abb\u00e8s Province"
     ],
@@ -63,7 +66,8 @@
         "\u03a3\u03af\u03bd\u03c4\u03b9 \u039c\u03c0\u03b5\u03bb \u0386\u03bc\u03c0\u03b5\u03c2"
     ],
     "name:ell_x_variant":[
-        "\u03a3\u03b9\u03bd\u03c4\u03af \u039c\u03c0\u03b5\u03bb \u0391\u03bc\u03c0\u03ad\u03c2"
+        "\u03a3\u03b9\u03bd\u03c4\u03af \u039c\u03c0\u03b5\u03bb \u0391\u03bc\u03c0\u03ad\u03c2",
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a3\u03b9\u03bd\u03c4\u03af \u039c\u03c0\u03b5\u03bb \u0391\u03bc\u03c0\u03ad\u03c2"
     ],
     "name:eng_x_preferred":[
         "Sidi Bel Abbes"
@@ -76,6 +80,9 @@
     "name:epo_x_preferred":[
         "Provinco Sidi Bel Abes"
     ],
+    "name:eus_x_preferred":[
+        "Sidi Bel Abbesko probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0633\u06cc\u062f\u06cc \u0628\u0644\u0639\u0628\u0627\u0633"
     ],
@@ -87,6 +94,9 @@
     ],
     "name:fra_x_variant":[
         "Sidi Bel Abb\u00e8s"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Sidi Bel Abb\u00e8s"
     ],
     "name:glg_x_preferred":[
         "Provincia de Sidi Bel Abbes"
@@ -214,6 +224,9 @@
     "name:zho_x_preferred":[
         "\u897f\u8fea\u8d1d\u52d2\u963f\u5df4\u65af\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Sidi Bel Abb\u00e8s Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -333,7 +346,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807359,
+    "wof:lastmodified":1690875489,
     "wof:name":"Sidi Bel Abbes",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/95/85670695.geojson
+++ b/data/856/706/95/85670695.geojson
@@ -38,6 +38,12 @@
     "name:arg_x_preferred":[
         "Termic\u00e9n"
     ],
+    "name:arq_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u062a\u0644\u0645\u0633\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0647 \u062a\u0644\u0645\u0633\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0644\u0645\u0633\u0627\u0646 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
@@ -62,6 +68,9 @@
     "name:ceb_x_preferred":[
         "Tlemcen"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Tlemcen"
+    ],
     "name:dan_x_preferred":[
         "Tlemcen"
     ],
@@ -73,6 +82,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03bb\u03b5\u03bc\u03c3\u03ad\u03bd"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03bb\u03b5\u03bc\u03c3\u03ad\u03bd"
     ],
     "name:eng_x_preferred":[
         "Tlemcen"
@@ -103,6 +115,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Tlemcen"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Tlemcen"
     ],
     "name:glg_x_preferred":[
         "Provincia de Tlemcen"
@@ -284,17 +299,26 @@
     "name:urd_x_variant":[
         "\u0635\u0648\u0628\u06c1 \u062a\u0644\u0645\u0633\u0627\u0646"
     ],
+    "name:uzb_x_preferred":[
+        "Tlemsen viloyati"
+    ],
     "name:vie_x_preferred":[
         "Tlemcen"
     ],
     "name:war_x_preferred":[
         "Tlemcen"
     ],
+    "name:wuu_x_preferred":[
+        "\u7279\u83b1\u59c6\u68ee\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u7279\u83b1\u59c6\u68ee"
     ],
     "name:zho_x_variant":[
         "\u7279\u83b1\u59c6\u68ee\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tlemcen Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -419,7 +443,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501712,
+    "wof:lastmodified":1690875489,
     "wof:name":"Tlemcen",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/99/85670699.geojson
+++ b/data/856/706/99/85670699.geojson
@@ -35,6 +35,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0634\u0627\u0631"
     ],
+    "name:ara_x_variant":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0628\u0634\u0627\u0631"
+    ],
     "name:aze_x_preferred":[
         "Be\u015far vilay\u0259ti"
     ],
@@ -56,6 +59,9 @@
     "name:ceb_x_preferred":[
         "Wilaya de B\u00e9char"
     ],
+    "name:cym_x_preferred":[
+        "Talaith B\u00e9char"
+    ],
     "name:dan_x_preferred":[
         "B\u00e9char"
     ],
@@ -67,6 +73,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03b5\u03c3\u03ac\u03c1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03c0\u03b5\u03c3\u03ac\u03c1"
     ],
     "name:eng_x_preferred":[
         "B\u00e9char"
@@ -91,6 +100,12 @@
     ],
     "name:fra_x_variant":[
         "B\u00e9char"
+    ],
+    "name:frr_x_preferred":[
+        "B\u00e9char"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige B\u00e9char"
     ],
     "name:glg_x_preferred":[
         "Provincia de B\u00e9char"
@@ -215,8 +230,14 @@
     "name:war_x_preferred":[
         "B\u00e9char"
     ],
+    "name:wuu_x_preferred":[
+        "\u8d1d\u6c99\u5c14\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u8d1d\u6c99\u5c14\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Bechar Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -338,7 +359,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614888966,
+    "wof:lastmodified":1690875490,
     "wof:name":"B\u00e9char",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/07/85670707.geojson
+++ b/data/856/707/07/85670707.geojson
@@ -41,6 +41,9 @@
     "name:azb_x_preferred":[
         "\u0646\u0639\u0627\u0645\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "Naama vilay\u0259ti"
+    ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u041d\u0430\u0430\u043c\u0430"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:ceb_x_preferred":[
         "Naama"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Naama"
     ],
     "name:dan_x_preferred":[
         "Naama Province"
@@ -75,6 +81,9 @@
     "name:epo_x_preferred":[
         "Provinco Naama"
     ],
+    "name:eus_x_preferred":[
+        "Na\u00e2mako probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0646\u0639\u0627\u0645\u0647"
     ],
@@ -86,6 +95,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Na\u00e2ma"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Naama"
     ],
     "name:glg_x_preferred":[
         "Provincia de Na\u00e2ma"
@@ -222,6 +234,9 @@
     "name:zho_x_preferred":[
         "\u7eb3\u9a6c\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Na\u00e2ma Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -342,7 +357,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807361,
+    "wof:lastmodified":1690875498,
     "wof:name":"Naama",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/09/85670709.geojson
+++ b/data/856/707/09/85670709.geojson
@@ -35,6 +35,9 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u062a\u0646\u062f\u0648\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0647 \u062a\u0646\u062f\u0648\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0646\u062f\u0648\u0641 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
@@ -59,6 +62,12 @@
     "name:ces_x_preferred":[
         "Tind\u00faf"
     ],
+    "name:che_x_preferred":[
+        "\u0422\u0438\u043d\u0434\u0443\u0444"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Tindouf"
+    ],
     "name:dan_x_preferred":[
         "Tindouf"
     ],
@@ -74,6 +83,9 @@
     "name:ell_x_preferred":[
         "\u03a4\u03b9\u03bd\u03c4\u03bf\u03cd\u03c6"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b9\u03bd\u03c4\u03bf\u03cd\u03c6"
+    ],
     "name:eng_x_preferred":[
         "Tindouf"
     ],
@@ -85,6 +97,9 @@
     ],
     "name:eus_x_preferred":[
         "Tinduf"
+    ],
+    "name:eus_x_variant":[
+        "Tindufeko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u062a\u0646\u062f\u0648\u0641"
@@ -106,6 +121,9 @@
     ],
     "name:frr_x_preferred":[
         "Tindouf"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Tindouf"
     ],
     "name:glg_x_preferred":[
         "Provincia de Tindouf"
@@ -281,6 +299,9 @@
     "name:zho_x_variant":[
         "\u5ef7\u675c\u592b\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Tindouf Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -401,7 +422,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501716,
+    "wof:lastmodified":1690875498,
     "wof:name":"Tindouf",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/13/85670713.geojson
+++ b/data/856/707/13/85670713.geojson
@@ -38,11 +38,17 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u0639\u0646\u0627\u0628\u0629"
     ],
+    "name:ast_x_preferred":[
+        "provincia d'Annaba"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0646\u0627\u0628\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
     "name:aze_x_preferred":[
         "Annaba vilay\u0259ti"
+    ],
+    "name:aze_x_variant":[
+        "\u018fnnab\u0259 vilay\u0259ti"
     ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u0410\u043d\u0430\u0431\u0430"
@@ -74,6 +80,9 @@
     "name:cym_x_preferred":[
         "Annaba"
     ],
+    "name:cym_x_variant":[
+        "Talaith Annaba"
+    ],
     "name:dan_x_preferred":[
         "Annaba"
     ],
@@ -101,6 +110,9 @@
     "name:eus_x_preferred":[
         "Annaba"
     ],
+    "name:eus_x_variant":[
+        "Annabako probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0639\u0646\u0627\u0628\u0647"
     ],
@@ -118,6 +130,12 @@
     ],
     "name:fra_x_variant":[
         "wilaya d'Annaba"
+    ],
+    "name:frr_x_preferred":[
+        "Annaba"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Annaba"
     ],
     "name:glg_x_preferred":[
         "Annaba"
@@ -296,17 +314,26 @@
     "name:uzb_x_preferred":[
         "Annaba"
     ],
+    "name:uzb_x_variant":[
+        "Annoba viloyati"
+    ],
     "name:vie_x_preferred":[
         "Annaba"
     ],
     "name:war_x_preferred":[
         "Annaba"
     ],
+    "name:wuu_x_preferred":[
+        "\u5b89\u7eb3\u5df4\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5b89\u7eb3\u5df4"
     ],
     "name:zho_x_variant":[
         "\u5b89\u7eb3\u5df4\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Annaba Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -428,7 +455,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501718,
+    "wof:lastmodified":1690875502,
     "wof:name":"Annaba",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/19/85670719.geojson
+++ b/data/856/707/19/85670719.geojson
@@ -38,8 +38,14 @@
     "name:ast_x_preferred":[
         "Provincia d'El Tarf"
     ],
+    "name:ast_x_variant":[
+        "provincia d'El Tarf"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0637\u0627\u0631\u0641 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "El-Tarf vilay\u0259ti"
     ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u042d\u043b\u044c-\u0422\u0430\u0440\u0444"
@@ -56,6 +62,9 @@
     "name:ceb_x_preferred":[
         "El Tarf"
     ],
+    "name:cym_x_preferred":[
+        "Talaith El Tarf"
+    ],
     "name:dan_x_preferred":[
         "El Tarf Province"
     ],
@@ -68,6 +77,9 @@
     "name:ell_x_preferred":[
         "\u0395\u03bb \u03a4\u03b1\u03c1\u03c6"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0395\u03bb \u03a4\u03b1\u03c1\u03c6"
+    ],
     "name:eng_x_preferred":[
         "El Tarf"
     ],
@@ -76,6 +88,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco El Tarf"
+    ],
+    "name:eus_x_preferred":[
+        "El Tarefeko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0627\u0644\u0637\u0627\u0631\u0641"
@@ -88,6 +103,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya d'El Tarf"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige El Tarf"
     ],
     "name:glg_x_preferred":[
         "Provincia de El Taref"
@@ -236,6 +254,9 @@
     "name:zho_x_variant":[
         "\u5854\u91cc\u592b\u7701"
     ],
+    "name:zul_x_preferred":[
+        "El Taref Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -358,7 +379,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501716,
+    "wof:lastmodified":1690875497,
     "wof:name":"El Tarf",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/23/85670723.geojson
+++ b/data/856/707/23/85670723.geojson
@@ -35,6 +35,9 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u062c\u064a\u062c\u0644"
     ],
+    "name:ary_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u062c\u064a\u062c\u0644"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u06cc\u062c\u0644 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
@@ -53,6 +56,9 @@
     "name:ceb_x_preferred":[
         "Jijel"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Jijel"
+    ],
     "name:dan_x_preferred":[
         "Jijel Province"
     ],
@@ -62,6 +68,9 @@
     "name:ell_x_preferred":[
         "\u03a4\u03b6\u03af\u03c4\u03b6\u03b5\u03bb"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b6\u03b9\u03c4\u03b6\u03ad\u03bb"
+    ],
     "name:eng_x_preferred":[
         "Jijel"
     ],
@@ -70,6 +79,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Jijel"
+    ],
+    "name:eus_x_preferred":[
+        "Jijelgo probintzia"
     ],
     "name:fas_x_preferred":[
         "\u062c\u06cc\u062c\u0644\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -85,6 +97,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Jijel"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Jijel"
     ],
     "name:glg_x_preferred":[
         "Jijel"
@@ -236,6 +251,9 @@
     "name:urd_x_variant":[
         "\u0635\u0648\u0628\u06c1 \u062c\u06cc\u062c\u0644"
     ],
+    "name:uzb_x_preferred":[
+        "Jijel viloyati"
+    ],
     "name:vie_x_preferred":[
         "Jijel"
     ],
@@ -247,6 +265,9 @@
     ],
     "name:zho_x_variant":[
         "\u5409\u6770\u52d2\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Jijel Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -368,7 +389,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501717,
+    "wof:lastmodified":1690875500,
     "wof:name":"Jijel",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/27/85670727.geojson
+++ b/data/856/707/27/85670727.geojson
@@ -50,6 +50,9 @@
     "name:cat_x_preferred":[
         "Prov\u00edncia de Skikda"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Skikda"
+    ],
     "name:dan_x_preferred":[
         "Skikda Province"
     ],
@@ -59,6 +62,9 @@
     "name:ell_x_preferred":[
         "\u03a3\u03ba\u03af\u03ba\u03bd\u03c4\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a3\u03ba\u03b9\u03ba\u03bd\u03c4\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Skikda"
     ],
@@ -67,6 +73,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Skikda"
+    ],
+    "name:eus_x_preferred":[
+        "Skikdako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0633\u06a9\u06cc\u06a9\u062f\u0647"
@@ -79,6 +88,9 @@
     ],
     "name:fra_x_variant":[
         "Skikda"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Skikda"
     ],
     "name:glg_x_preferred":[
         "Provincia de Skikda"
@@ -203,6 +215,9 @@
     "name:zho_x_preferred":[
         "\u65af\u57fa\u514b\u8fbe\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Skikda Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -322,7 +337,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501715,
+    "wof:lastmodified":1690875497,
     "wof:name":"Skikda",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/31/85670731.geojson
+++ b/data/856/707/31/85670731.geojson
@@ -62,6 +62,9 @@
     "name:ces_x_preferred":[
         "Illizi"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Illizi"
+    ],
     "name:dan_x_preferred":[
         "Illizi Province"
     ],
@@ -70,6 +73,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0399\u03bb\u03bb\u03af\u03b6\u03b9"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0399\u03bb\u03b9\u03b6\u03af"
     ],
     "name:eng_x_preferred":[
         "Illizi"
@@ -83,6 +89,9 @@
     "name:epo_x_variant":[
         "Provinco Ilizi"
     ],
+    "name:eus_x_preferred":[
+        "Illiziko probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0627\u0644\u06cc\u0632\u06cc"
     ],
@@ -94,6 +103,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya d'Illizi"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Illizi"
     ],
     "name:glg_x_preferred":[
         "Provincia de Illizi"
@@ -251,6 +263,9 @@
     "name:zho_x_variant":[
         "\u4f0a\u5229\u6d4e\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Illizi Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -371,7 +386,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501716,
+    "wof:lastmodified":1690875499,
     "wof:name":"Illizi",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/35/85670735.geojson
+++ b/data/856/707/35/85670735.geojson
@@ -51,6 +51,12 @@
     "name:cat_x_preferred":[
         "Prov\u00edncia de Tamanghasset"
     ],
+    "name:che_x_preferred":[
+        "\u0422\u0430\u043c\u0430\u043d\u0440\u0430\u0441\u0441\u0435\u0442"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Tamanghasset"
+    ],
     "name:dan_x_preferred":[
         "Tamanghasset Province"
     ],
@@ -59,6 +65,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b1\u03bc\u03b1\u03b3\u03ba\u03b1\u03c3\u03c3\u03ad\u03c4"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b1\u03bc\u03b1\u03bd\u03c1\u03b1\u03c3\u03c3\u03ad\u03c4"
     ],
     "name:eng_x_preferred":[
         "Tamanghasset"
@@ -89,6 +98,9 @@
     "name:fra_x_variant":[
         "Tamanrasset"
     ],
+    "name:gle_x_preferred":[
+        "C\u00faige Tamanrasset"
+    ],
     "name:glg_x_preferred":[
         "Provincia de Tamanrasset"
     ],
@@ -103,6 +115,9 @@
     ],
     "name:hun_x_preferred":[
         "Tamanghasset"
+    ],
+    "name:hye_x_preferred":[
+        "\u0539\u0561\u0574\u0561\u0576\u0580\u0561\u057d\u0565\u0569"
     ],
     "name:ind_x_preferred":[
         "Provinsi Tamanghasset"
@@ -221,8 +236,14 @@
     "name:war_x_preferred":[
         "Tamanrasset"
     ],
+    "name:wuu_x_preferred":[
+        "\u5854\u66fc\u62c9\u585e\u7279\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5854\u66fc\u62c9\u585e\u7279\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tamanrasset Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -342,7 +363,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501715,
+    "wof:lastmodified":1690875496,
     "wof:name":"Tamanghasset",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/41/85670741.geojson
+++ b/data/856/707/41/85670741.geojson
@@ -38,6 +38,9 @@
     "name:ast_x_preferred":[
         "Provincia d'El Bayadh"
     ],
+    "name:ast_x_variant":[
+        "provincia d'El Bayadh"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0628\u06cc\u0636 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
@@ -56,6 +59,9 @@
     "name:ceb_x_preferred":[
         "El Bayadh"
     ],
+    "name:cym_x_preferred":[
+        "Talaith El Bayadh"
+    ],
     "name:dan_x_preferred":[
         "El Bayadh"
     ],
@@ -65,6 +71,9 @@
     "name:ell_x_preferred":[
         "\u0395\u03bb \u039c\u03c0\u03ac\u03b3\u03b9\u03b1\u03b4"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0395\u03bb \u039c\u03c0\u03b1\u03b3\u03b9\u03ac\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "El Bayadh"
     ],
@@ -73,6 +82,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco El Bajdah"
+    ],
+    "name:eus_x_preferred":[
+        "El Bayadheko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0628\u06cc\u0636"
@@ -88,6 +100,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya d'El Bayadh"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige El Bayadh"
     ],
     "name:glg_x_preferred":[
         "Provincia de El Bayadh"
@@ -239,6 +254,9 @@
     "name:zho_x_variant":[
         "\u5df4\u4e9a\u5179\u7701"
     ],
+    "name:zul_x_preferred":[
+        "El Bayadh Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -359,7 +377,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501717,
+    "wof:lastmodified":1690875500,
     "wof:name":"El Bayadh",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/45/85670745.geojson
+++ b/data/856/707/45/85670745.geojson
@@ -38,6 +38,9 @@
     "name:ast_x_preferred":[
         "Provincia d'El Oued"
     ],
+    "name:ast_x_variant":[
+        "provincia d'El Oued"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0648\u0627\u062f\u06cc \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
@@ -59,6 +62,9 @@
     "name:ceb_x_preferred":[
         "El Oued"
     ],
+    "name:cym_x_preferred":[
+        "Talaith El Oued"
+    ],
     "name:dan_x_preferred":[
         "El Oued"
     ],
@@ -68,6 +74,9 @@
     "name:ell_x_preferred":[
         "\u0395\u03bb \u039f\u03c5\u03ad\u03bd\u03c4"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0395\u03bb \u039f\u03c5\u03ad\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "El Oued"
     ],
@@ -76,6 +85,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco El Ued"
+    ],
+    "name:eus_x_preferred":[
+        "El Ouedeko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0648\u0627\u062f\u06cc\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -91,6 +103,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya d'El Oued"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige El Oued"
     ],
     "name:glg_x_preferred":[
         "Provincia de El Oued"
@@ -139,6 +154,9 @@
     ],
     "name:lad_x_preferred":[
         "Wilaya de El Wed"
+    ],
+    "name:lat_x_preferred":[
+        "Potamopolitana"
     ],
     "name:lav_x_preferred":[
         "V\u0101das vil\u0101ja"
@@ -259,6 +277,9 @@
     ],
     "name:zho_x_variant":[
         "\u74e6\u8fea\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "El Oued Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -383,7 +404,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501715,
+    "wof:lastmodified":1690875497,
     "wof:name":"El Oued",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/49/85670749.geojson
+++ b/data/856/707/49/85670749.geojson
@@ -36,7 +36,8 @@
         "\u063a\u0631\u062f\u0627\u064a\u0629"
     ],
     "name:ara_x_variant":[
-        "Ghardaia"
+        "Ghardaia",
+        "\u0648\u0644\u0627\u064a\u0629 \u063a\u0631\u062f\u0627\u064a\u0629"
     ],
     "name:azb_x_preferred":[
         "\u063a\u0631\u062f\u0627\u06cc\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
@@ -62,14 +63,23 @@
     "name:ces_x_preferred":[
         "Ghard\u00e1ja"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Gharda\u00efa"
+    ],
     "name:dan_x_preferred":[
         "Gharda\u00efa Province"
     ],
     "name:deu_x_preferred":[
         "Ghardaia"
     ],
+    "name:deu_x_variant":[
+        "Wilaya Ghardaia"
+    ],
     "name:ell_x_preferred":[
         "\u0393\u03b1\u03c1\u03bd\u03c4\u03ac\u03b9\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0393\u03ba\u03b1\u03c1\u03bd\u03c4\u03ac\u03b9\u03b1"
     ],
     "name:eng_x_preferred":[
         "Ghardaia"
@@ -82,6 +92,9 @@
     "name:epo_x_preferred":[
         "Provinco Ghardaia"
     ],
+    "name:eus_x_preferred":[
+        "Ghardaiako probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u063a\u0631\u062f\u0627\u06cc\u0647"
     ],
@@ -93,6 +106,9 @@
     ],
     "name:fra_x_variant":[
         "Gharda\u00efa"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Gharda\u00efa"
     ],
     "name:glg_x_preferred":[
         "Provincia de Gharda\u00efa"
@@ -178,6 +194,9 @@
     "name:tam_x_preferred":[
         "\u0b95\u0bbe\u0bb0\u0bcd\u0b9f\u0bc8\u0baf\u0bc7  \u0bae\u0bbe\u0b95\u0bbe\u0ba3\u0bae\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0b95\u0bbe\u0bb0\u0bcd\u0b9f\u0bc8\u0baf\u0bc7 \u0bae\u0bbe\u0b95\u0bbe\u0ba3\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c17\u0c3e\u0c30\u0c4d\u0c21\u0c3e\u0c2f\u0c3f\u0c2f\u0c3e \u0c2a\u0c4d\u0c30\u0c3e\u0c35\u0c3f\u0c28\u0c4d\u0c38\u0c4d"
     ],
@@ -207,6 +226,9 @@
     ],
     "name:zho_x_preferred":[
         "\u76d6\u5c14\u8fbe\u8036\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Gharda\u00efa Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -328,7 +350,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501717,
+    "wof:lastmodified":1690875501,
     "wof:name":"Ghardaia",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/53/85670753.geojson
+++ b/data/856/707/53/85670753.geojson
@@ -56,6 +56,9 @@
     "name:ceb_x_preferred":[
         "Laghouat"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Laghouat"
+    ],
     "name:dan_x_preferred":[
         "Laghouat Province"
     ],
@@ -67,6 +70,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039b\u03b1\u03b3\u03ba\u03bf\u03c5\u03ac\u03c4"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039b\u03b1\u03b3\u03ba\u03bf\u03c5\u03ac\u03c4"
     ],
     "name:eng_x_preferred":[
         "Laghouat"
@@ -94,6 +100,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Laghouat"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Laghouat"
     ],
     "name:glg_x_preferred":[
         "Provincia de Laghouat"
@@ -248,11 +257,17 @@
     "name:war_x_preferred":[
         "Laghouat"
     ],
+    "name:wuu_x_preferred":[
+        "\u827e\u683c\u74e6\u7279\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u827e\u683c\u74e6\u7279"
     ],
     "name:zho_x_variant":[
         "\u827e\u683c\u74e6\u7279\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Laghouat Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -374,7 +389,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501716,
+    "wof:lastmodified":1690875499,
     "wof:name":"Laghouat",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/59/85670759.geojson
+++ b/data/856/707/59/85670759.geojson
@@ -38,6 +38,9 @@
     "name:ast_x_preferred":[
         "Provincia d'Ouargla"
     ],
+    "name:ast_x_variant":[
+        "provincia d'Ouargla"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0631\u0642\u0644\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
@@ -62,6 +65,9 @@
     "name:ceb_x_preferred":[
         "Ouargla"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Ouargla"
+    ],
     "name:dan_x_preferred":[
         "Ouargla Province"
     ],
@@ -71,6 +77,9 @@
     "name:ell_x_preferred":[
         "\u039f\u03c5\u03ad\u03c1\u03b3\u03ba\u03bb\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039f\u03c5\u03ac\u03c1\u03b3\u03ba\u03bb\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Ouargla"
     ],
@@ -79,6 +88,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Uargla"
+    ],
+    "name:eus_x_preferred":[
+        "Ouarglako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0648\u0631\u0642\u0644\u0647\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -97,6 +109,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya d'Ouargla"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Ouargla"
     ],
     "name:glg_x_preferred":[
         "Provincia de Ouargla"
@@ -260,6 +275,9 @@
     "name:zho_x_variant":[
         "\u74e6\u5c14\u683c\u62c9\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Ouargla Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -383,7 +401,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501715,
+    "wof:lastmodified":1690875496,
     "wof:name":"Ouargla",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/61/85670761.geojson
+++ b/data/856/707/61/85670761.geojson
@@ -35,6 +35,12 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u062c\u0632\u0627\u0626\u0631"
     ],
+    "name:ast_x_preferred":[
+        "provincia d'Algiers"
+    ],
+    "name:aze_x_preferred":[
+        "\u018flc\u0259zair vilay\u0259ti"
+    ],
     "name:bel_x_preferred":[
         "\u043f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u0410\u043b\u0436\u044b\u0440"
     ],
@@ -47,11 +53,23 @@
     "name:cat_x_preferred":[
         "Prov\u00edncia d'Alger"
     ],
+    "name:cat_x_variant":[
+        "prov\u00edncia d'Alger"
+    ],
+    "name:cos_x_preferred":[
+        "pruvincia d'Algeri"
+    ],
+    "name:cym_x_preferred":[
+        "Talaith Algiers"
+    ],
     "name:dan_x_preferred":[
         "Algier"
     ],
     "name:deu_x_preferred":[
         "Algier"
+    ],
+    "name:ell_x_preferred":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0391\u03bb\u03b3\u03b5\u03c1\u03af\u03bf\u03c5"
     ],
     "name:eng_x_preferred":[
         "Alger"
@@ -86,6 +104,9 @@
     ],
     "name:hun_x_preferred":[
         "Alg\u00edr"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u056c\u056a\u056b\u0580"
     ],
     "name:ind_x_preferred":[
         "Provinsi Aljir"
@@ -186,11 +207,17 @@
     "name:war_x_preferred":[
         "Algiers"
     ],
+    "name:wuu_x_preferred":[
+        "\u963f\u5c14\u53ca\u5c14\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u5c14\u53ca\u5c14"
     ],
     "name:zho_x_variant":[
         "\u963f\u5c14\u53ca\u5c14\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Algiers Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -312,7 +339,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501714,
+    "wof:lastmodified":1690875496,
     "wof:name":"Alger",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/65/85670765.geojson
+++ b/data/856/707/65/85670765.geojson
@@ -36,10 +36,17 @@
         "\u0628\u0648\u0645\u0631\u062f\u0627\u0633"
     ],
     "name:ara_x_variant":[
-        "Boumerdes"
+        "Boumerdes",
+        "\u0648\u0644\u0627\u064a\u0629 \u0628\u0648\u0645\u0631\u062f\u0627\u0633"
+    ],
+    "name:arq_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0628\u0648\u0645\u0631\u062f\u0627\u0633"
     ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u0645\u0631\u062f\u0627\u0633 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "Bumerdes vilay\u0259ti"
     ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u0411\u0443\u043c\u0435\u0440\u0434\u044d\u0441"
@@ -59,6 +66,9 @@
     "name:ceb_x_preferred":[
         "Wilaya de Boumerdes"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Boumerd\u00e8s"
+    ],
     "name:dan_x_preferred":[
         "Boumerd\u00e8s Province"
     ],
@@ -67,6 +77,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bf\u03c5\u03bc\u03b5\u03c1\u03bd\u03c4\u03ad\u03c2"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03c0\u03bf\u03c5\u03bc\u03b5\u03c1\u03bd\u03c4\u03ad\u03c2"
     ],
     "name:eng_x_preferred":[
         "Boumerdes"
@@ -78,6 +91,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Bumerdes"
+    ],
+    "name:eus_x_preferred":[
+        "Boumerdesko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0628\u0648\u0645\u0631\u062f\u0627\u0633"
@@ -92,11 +108,17 @@
         "wilaya de Boumerd\u00e8s",
         "Boumerd\u00e8s"
     ],
+    "name:gle_x_preferred":[
+        "C\u00faige Boumerd\u00e8s"
+    ],
     "name:glg_x_preferred":[
         "Provincia de Boumerd\u00e8s"
     ],
     "name:guj_x_preferred":[
         "\u0aac\u0acb\u0aae\u0ac7\u0ab0\u0acd\u0aa1\u0ac7\u0ab8 \u0aaa\u0acd\u0ab0\u0abe\u0a82\u0aa4"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e4\u05e8\u05d5\u05d1\u05d9\u05e0\u05e6\u05d9\u05d9\u05ea \u05d1\u05d5\u05de\u05e8\u05d3\u05e1"
     ],
     "name:hin_x_preferred":[
         "\u092c\u094b\u0909\u092e\u0947\u0930\u094d\u0921\u0947\u0938 \u092a\u094d\u0930\u093e\u0902\u0924"
@@ -214,6 +236,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e03\u7c73\u5c14\u8fbe\u65af\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Boumerd\u00e8s Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -335,7 +360,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807362,
+    "wof:lastmodified":1690875499,
     "wof:name":"Boumerdes",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/67/85670767.geojson
+++ b/data/856/707/67/85670767.geojson
@@ -59,6 +59,9 @@
     "name:ceb_x_preferred":[
         "Tizi Ouzou"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Tizi Ouzou"
+    ],
     "name:dan_x_preferred":[
         "Tizi Ouzou Province"
     ],
@@ -67,6 +70,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b9\u03b6\u03af \u039f\u03c5\u03b6\u03bf\u03cd"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b9\u03b6\u03af \u039f\u03c5\u03b6\u03bf\u03cd"
     ],
     "name:eng_x_preferred":[
         "Tizi Ouzou"
@@ -100,6 +106,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Tizi Ouzou"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Tizi Ouzou"
     ],
     "name:glg_x_preferred":[
         "Provincia de Tizi Ouzou"
@@ -260,11 +269,17 @@
     "name:war_x_preferred":[
         "Tizi Ouzou"
     ],
+    "name:wuu_x_preferred":[
+        "\u63d0\u6d4e\u4e4c\u7956\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u63d0\u6d4e\u4e4c\u7956"
     ],
     "name:zho_x_variant":[
         "\u63d0\u6d4e\u4e4c\u7956\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tizi Ouzou Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -386,7 +401,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501715,
+    "wof:lastmodified":1690875496,
     "wof:name":"Tizi Ouzou",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/71/85670771.geojson
+++ b/data/856/707/71/85670771.geojson
@@ -54,6 +54,9 @@
     "name:cat_x_preferred":[
         "Prov\u00edncia de Tipaza"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Tipasa"
+    ],
     "name:dan_x_preferred":[
         "Tipasa Province"
     ],
@@ -62,6 +65,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b9\u03c0\u03ac\u03c3\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b9\u03c0\u03b1\u03b6\u03ac"
     ],
     "name:eng_x_preferred":[
         "Tipaza"
@@ -88,6 +94,9 @@
     "name:fra_x_variant":[
         "Tipaza"
     ],
+    "name:gle_x_preferred":[
+        "C\u00faige Tipasa"
+    ],
     "name:glg_x_preferred":[
         "Provincia de Tipaza"
     ],
@@ -102,6 +111,9 @@
     ],
     "name:hun_x_preferred":[
         "Tip\u00e1za"
+    ],
+    "name:hye_x_preferred":[
+        "\u054f\u056b\u057a\u0561\u057d\u0561"
     ],
     "name:ina_x_preferred":[
         "Provincia Tipaza"
@@ -216,6 +228,9 @@
     ],
     "name:zho_x_preferred":[
         "\u63d0\u5e15\u8428\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tipaza Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -337,7 +352,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501717,
+    "wof:lastmodified":1690875501,
     "wof:name":"Tipaza",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/77/85670777.geojson
+++ b/data/856/707/77/85670777.geojson
@@ -33,10 +33,14 @@
         "\u0639\u064a\u0646 \u0627\u0644\u062f\u0641\u0644\u0649"
     ],
     "name:ara_x_variant":[
-        "Ain Defla"
+        "Ain Defla",
+        "\u0648\u0644\u0627\u064a\u0629 \u0639\u064a\u0646 \u0627\u0644\u062f\u0641\u0644\u0649"
     ],
     "name:ast_x_preferred":[
         "Provincia d'A\u00edn Defla"
+    ],
+    "name:ast_x_variant":[
+        "provincia d'A\u00edn Defla"
     ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0627\u0644\u062f\u0641\u0644\u06cc \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
@@ -62,6 +66,9 @@
     "name:ceb_x_preferred":[
         "Wilaya de A\u00efn Defla"
     ],
+    "name:cym_x_preferred":[
+        "Talaith A\u00efn Defla"
+    ],
     "name:dan_x_preferred":[
         "A\u00efn Defla"
     ],
@@ -70,6 +77,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0391\u03ca\u03bd \u039d\u03c4\u03ad\u03c6\u03bb\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0391\u0390\u03bd \u039d\u03c4\u03b5\u03c6\u03bb\u03ac"
     ],
     "name:eng_x_preferred":[
         "A\u00efn Defla"
@@ -80,8 +90,14 @@
     "name:epo_x_preferred":[
         "Provinco Ajn Defla"
     ],
+    "name:eus_x_preferred":[
+        "Ain Deflako probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0639\u06cc\u0646 \u0627\u0644\u062f\u0641\u0644\u06cc"
+    ],
+    "name:fas_x_variant":[
+        "\u0627\u0633\u062a\u0627\u0646 \u0639\u06cc\u0646\u200c\u0627\u0644\u062f\u0641\u0644\u06cc"
     ],
     "name:fin_x_preferred":[
         "A\u00efn Deflan provinssi"
@@ -91,6 +107,12 @@
     ],
     "name:fra_x_variant":[
         "A\u00efn Defla"
+    ],
+    "name:frr_x_preferred":[
+        "A\u00efn Defla"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige A\u00efn Defla"
     ],
     "name:glg_x_preferred":[
         "Provincia de A\u00efn Defla"
@@ -185,6 +207,9 @@
     "name:tam_x_preferred":[
         "\u0b85\u0baf\u0bcd\u0ba9\u0bcd \u0b9f\u0bc7\u0baa\u0bcd\u0baa\u0bbf\u0bb2\u0bbe  \u0bae\u0bbe\u0b95\u0bbe\u0ba3\u0bae\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0b85\u0baf\u0bcd\u0ba9\u0bcd \u0b9f\u0bc7\u0baa\u0bcd\u0baa\u0bbf\u0bb2\u0bbe \u0bae\u0bbe\u0b95\u0bbe\u0ba3\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c0e\u0c2f\u0c3f\u0c28\u0c4d \u0c21\u0c46\u0c2b\u0c4d\u0c32\u0c3e \u0c2a\u0c4d\u0c30\u0c3e\u0c35\u0c3f\u0c28\u0c4d\u0c38\u0c4d"
     ],
@@ -212,8 +237,14 @@
     "name:war_x_preferred":[
         "A\u00efn Defla"
     ],
+    "name:wuu_x_preferred":[
+        "\u827e\u56e0\u8fea\u592b\u62c9\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u8fea\u592b\u62c9\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Defla Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -335,7 +366,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807362,
+    "wof:lastmodified":1690875500,
     "wof:name":"A\u00efn Defla",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/81/85670781.geojson
+++ b/data/856/707/81/85670781.geojson
@@ -53,6 +53,9 @@
     "name:ceb_x_preferred":[
         "Chlef"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Chlef"
+    ],
     "name:dan_x_preferred":[
         "Chlef Province"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03bb\u03b5\u03c6"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a3\u03bb\u03b5\u03c6"
     ],
     "name:eng_x_preferred":[
         "Chlef"
@@ -88,6 +94,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Chlef"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Chlef"
     ],
     "name:glg_x_preferred":[
         "Provincia de Chlef"
@@ -245,11 +254,17 @@
     "name:war_x_preferred":[
         "Chlef"
     ],
+    "name:wuu_x_preferred":[
+        "\u8c22\u91cc\u592b\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u8c22\u91cc\u592b\u5e02"
     ],
     "name:zho_x_variant":[
         "\u8c22\u91cc\u592b\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Chlef Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -373,7 +388,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501716,
+    "wof:lastmodified":1690875498,
     "wof:name":"Chlef",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/85/85670785.geojson
+++ b/data/856/707/85/85670785.geojson
@@ -50,6 +50,9 @@
     "name:ces_x_preferred":[
         "\u0158asenka"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Mascara"
+    ],
     "name:dan_x_preferred":[
         "Mascara"
     ],
@@ -65,6 +68,9 @@
     "name:ell_x_preferred":[
         "\u039c\u03ac\u03c3\u03ba\u03b1\u03c1\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03ac\u03c3\u03ba\u03b1\u03c1\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Mascara"
     ],
@@ -79,6 +85,9 @@
     ],
     "name:eus_x_preferred":[
         "Errimel"
+    ],
+    "name:eus_x_variant":[
+        "Mascarako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0631\u06cc\u0645\u0644"
@@ -97,6 +106,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Mascara"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Mascara"
     ],
     "name:glg_x_preferred":[
         "Provincia de Mascara"
@@ -176,6 +188,9 @@
     "name:nor_x_preferred":[
         "Maskara"
     ],
+    "name:oss_x_preferred":[
+        "\u041c\u0430\u0441\u043a\u0430\u0440\u00e6"
+    ],
     "name:pnb_x_preferred":[
         "\u0645\u0639\u0633\u06a9\u0631"
     ],
@@ -236,6 +251,9 @@
     "name:tam_x_preferred":[
         "\u0b95\u0ba3\u0bcd\u0ba3\u0bbf\u0bae\u0bc8\u0bae\u0bc1\u0b9f\u0bbf\u0b9a\u0bcd \u0b9a\u0bbe\u0baf\u0bae\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0bae\u0bbe\u0bb8\u0bcd\u0b95\u0bcd\u0b95\u0bbe\u0bb0 \u0bae\u0bbe\u0b95\u0bbe\u0ba3\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c38\u0c4d\u0c15\u0c3e\u0c30\u0c3e \u0c2a\u0c4d\u0c30\u0c3e\u0c35\u0c3f\u0c28\u0c4d\u0c38\u0c4d"
     ],
@@ -269,6 +287,9 @@
     "name:urd_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u0645\u0639\u0633\u06a9\u0631"
     ],
+    "name:uzb_x_preferred":[
+        "Mascara viloyati"
+    ],
     "name:vie_x_preferred":[
         "Mascara"
     ],
@@ -280,6 +301,9 @@
     ],
     "name:zho_x_variant":[
         "\u7a46\u963f\u65af\u51ef\u5c14\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Mascara Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -401,7 +425,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501717,
+    "wof:lastmodified":1690875501,
     "wof:name":"Mascara",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/87/85670787.geojson
+++ b/data/856/707/87/85670787.geojson
@@ -35,11 +35,20 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u0645\u0633\u062a\u063a\u0627\u0646\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0633\u062a\u062c\u0627\u0646\u0645"
+    ],
+    "name:ast_x_preferred":[
+        "Mostaganem"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0633\u062a\u063a\u0627\u0646\u0645"
     ],
     "name:aze_x_preferred":[
         "Mostaqanem"
+    ],
+    "name:bel_x_preferred":[
+        "\u041c\u0430\u0441\u0442\u0430\u0433\u0430\u043d\u0435\u043c"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09cb\u09b8\u09cd\u09a4\u09be\u0997\u09be\u09a8\u09c7\u09ae"
@@ -143,6 +152,9 @@
     "name:nob_x_preferred":[
         "Mostaganem"
     ],
+    "name:oss_x_preferred":[
+        "\u041c\u043e\u0441\u0442\u0430\u0433\u0430\u043d\u0435\u043c"
+    ],
     "name:pnb_x_preferred":[
         "\u0645\u0633\u062a\u0627\u063a\u0627\u0646\u0645"
     ],
@@ -169,6 +181,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041c\u043e\u0441\u0442\u0430\u0433\u0430\u043d\u0435\u043c"
+    ],
+    "name:swa_x_preferred":[
+        "Mostaganem"
     ],
     "name:swe_x_preferred":[
         "Mostaganem"
@@ -326,7 +341,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501715,
+    "wof:lastmodified":1690875497,
     "wof:name":"Mostaganem",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/91/85670791.geojson
+++ b/data/856/707/91/85670791.geojson
@@ -53,6 +53,9 @@
     "name:ceb_x_preferred":[
         "Relizane"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Relizane"
+    ],
     "name:dan_x_preferred":[
         "Relizane Province"
     ],
@@ -62,6 +65,9 @@
     "name:ell_x_preferred":[
         "\u03a1\u03b5\u03bb\u03b9\u03b6\u03ac\u03bd"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a1\u03b5\u03bb\u03b9\u03b6\u03ac\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Relizane"
     ],
@@ -70,6 +76,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Relizan"
+    ],
+    "name:eus_x_preferred":[
+        "Relizaneko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u063a\u0644\u06cc\u0632\u0627\u0646\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -85,6 +94,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Relizane"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Relizane"
     ],
     "name:glg_x_preferred":[
         "Provincia de Relizane"
@@ -246,7 +258,11 @@
         "\u57c3\u5229\u8d5e"
     ],
     "name:zho_x_variant":[
-        "\u57c3\u5229\u8d5e\u7701"
+        "\u57c3\u5229\u8d5e\u7701",
+        "\u57c3\u5229\u8d0a\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Relizane Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -368,7 +384,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501716,
+    "wof:lastmodified":1690875499,
     "wof:name":"Relizane",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/97/85670797.geojson
+++ b/data/856/707/97/85670797.geojson
@@ -36,7 +36,8 @@
         "\u0633\u0639\u064a\u062f\u0629\u200e"
     ],
     "name:ara_x_variant":[
-        "Saida"
+        "Saida",
+        "\u0648\u0644\u0627\u064a\u0629 \u0633\u0639\u064a\u062f\u0629"
     ],
     "name:azb_x_preferred":[
         "\u0633\u0639\u06cc\u062f\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
@@ -65,6 +66,9 @@
     "name:ces_x_preferred":[
         "Saida"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Sa\u00efda"
+    ],
     "name:dan_x_preferred":[
         "Sa\u00efda Province"
     ],
@@ -75,7 +79,8 @@
         "\u03a3\u03ac\u03b9\u03bd\u03c4\u03b1"
     ],
     "name:ell_x_variant":[
-        "\u03a3\u03b1\u03ca\u03bd\u03c4\u03ac"
+        "\u03a3\u03b1\u03ca\u03bd\u03c4\u03ac",
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a3\u03b1\u03ca\u03bd\u03c4\u03ac"
     ],
     "name:eng_x_preferred":[
         "Saida"
@@ -88,6 +93,9 @@
     "name:epo_x_preferred":[
         "Provinco Saida"
     ],
+    "name:eus_x_preferred":[
+        "Saidako probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0633\u0639\u06cc\u062f\u0647"
     ],
@@ -99,6 +107,9 @@
     ],
     "name:fra_x_variant":[
         "Sa\u00efda"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Sa\u00efda"
     ],
     "name:glg_x_preferred":[
         "Provincia de Sa\u00efda"
@@ -229,6 +240,9 @@
     "name:zho_x_preferred":[
         "\u8d5b\u4f0a\u8fbe\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Sa\u00efda Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -349,7 +363,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501717,
+    "wof:lastmodified":1690875500,
     "wof:name":"Saida",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/01/85670801.geojson
+++ b/data/856/708/01/85670801.geojson
@@ -56,6 +56,9 @@
     "name:ceb_x_preferred":[
         "Tiaret"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Tiaret"
+    ],
     "name:dan_x_preferred":[
         "Tiaret Province"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b9\u03b1\u03c1\u03ad\u03c4"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b9\u03b1\u03c1\u03ad\u03c4"
     ],
     "name:eng_x_preferred":[
         "Tiaret"
@@ -94,6 +100,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Tiaret"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Tiaret"
     ],
     "name:glg_x_preferred":[
         "Provincia de Tiaret"
@@ -245,11 +254,17 @@
     "name:war_x_preferred":[
         "Tiaret"
     ],
+    "name:wuu_x_preferred":[
+        "\u63d0\u4e9a\u96f7\u7279\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u63d0\u4e9a\u96f7\u7279"
     ],
     "name:zho_x_variant":[
         "\u63d0\u4e9a\u96f7\u7279\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tiaret Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -374,7 +389,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501714,
+    "wof:lastmodified":1690875494,
     "wof:name":"Tiaret",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/05/85670805.geojson
+++ b/data/856/708/05/85670805.geojson
@@ -54,6 +54,9 @@
     "name:ceb_x_preferred":[
         "Tissemsilt"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Tissemsilt"
+    ],
     "name:dan_x_preferred":[
         "Tissemsilt Province"
     ],
@@ -62,6 +65,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b9\u03c3\u03c3\u03b5\u03bc\u03c3\u03af\u03bb\u03c4"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b9\u03c3\u03b5\u03bc\u03c3\u03af\u03bb\u03c4"
     ],
     "name:eng_x_preferred":[
         "Tissemsilt"
@@ -72,8 +78,14 @@
     "name:epo_x_preferred":[
         "Provinco Tisemsilt"
     ],
+    "name:eus_x_preferred":[
+        "Tissemsilteko probintzia"
+    ],
     "name:fas_x_preferred":[
         "\u062a\u0633\u0645\u0633\u06cc\u0644\u062a"
+    ],
+    "name:fas_x_variant":[
+        "\u0627\u0633\u062a\u0627\u0646 \u062a\u06cc\u0633\u0645\u0633\u06cc\u0644\u062a"
     ],
     "name:fin_x_preferred":[
         "Tissemsiltin provinssi"
@@ -83,6 +95,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Tissemsilt"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Tissemsilt"
     ],
     "name:glg_x_preferred":[
         "Provincia de Tissemsilt"
@@ -231,6 +246,9 @@
     "name:zho_x_variant":[
         "\u63d0\u585e\u59c6\u897f\u52d2\u7279\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Tissemsilt Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -353,7 +371,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501713,
+    "wof:lastmodified":1690875492,
     "wof:name":"Tissemsilt",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/09/85670809.geojson
+++ b/data/856/708/09/85670809.geojson
@@ -33,7 +33,8 @@
         "\u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c\u200e"
     ],
     "name:ara_x_variant":[
-        "Bordj Bou Arreridj"
+        "Bordj Bou Arreridj",
+        "\u0648\u0644\u0627\u064a\u0629 \u0628\u0631\u062c \u0628\u0648\u0639\u0631\u064a\u0631\u064a\u062c"
     ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u062c \u0628\u0648\u0639\u0631\u06cc\u0631\u06cc\u062c \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
@@ -59,6 +60,9 @@
     "name:ceb_x_preferred":[
         "Wilaya de Bordj Bou Arr\u00e9ridj"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Bordj Bou Arr\u00e9ridj"
+    ],
     "name:dan_x_preferred":[
         "Bordj Bou Arr\u00e9ridj"
     ],
@@ -68,6 +72,9 @@
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bf\u03c1\u03bd\u03c4\u03b6 \u039c\u03c0\u03bf\u03c5 \u0391\u03c1\u03b5\u03c1\u03af\u03bd\u03c4\u03b6"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03c4\u03bf\u03c5 \u039c\u03c0\u03bf\u03c1\u03c4\u03b6 \u039c\u03c0\u03bf\u03c5 \u0391\u03c1\u03b5\u03c1\u03af\u03c4\u03b6"
+    ],
     "name:eng_x_preferred":[
         "Bordj Bou Arr\u00e9ridj"
     ],
@@ -76,6 +83,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Bor\u011d Bu Areri\u011d"
+    ],
+    "name:eus_x_preferred":[
+        "Bordj Bou Arreridjeko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0628\u0631\u062c \u0628\u0648\u0639\u0631\u06cc\u0631\u06cc\u062c"
@@ -88,6 +98,9 @@
     ],
     "name:fra_x_variant":[
         "Bordj Bou Arreridj"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Bordj Bou Arr\u00e9ridj"
     ],
     "name:glg_x_preferred":[
         "Provincia de Bordj Bou Arr\u00e9ridj"
@@ -208,6 +221,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e03\u963f\u62c9\u91cc\u5b63\u5821\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Bordj Bou Arr\u00e9ridj Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -330,7 +346,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807360,
+    "wof:lastmodified":1690875493,
     "wof:name":"Bordj Bou Arr\u00e9ridj",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/15/85670815.geojson
+++ b/data/856/708/15/85670815.geojson
@@ -36,7 +36,8 @@
         "\u0628\u0650\u062c\u064e\u0627\u064a\u064e\u0629\u200e"
     ],
     "name:ara_x_variant":[
-        "Bejaia"
+        "Bejaia",
+        "\u0648\u0644\u0627\u064a\u0629 \u0628\u062c\u0627\u064a\u0629"
     ],
     "name:azb_x_preferred":[
         "\u0628\u062c\u0627\u06cc\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
@@ -62,14 +63,23 @@
     "name:ceb_x_preferred":[
         "Wilaya de Beja\u00efa"
     ],
+    "name:cym_x_preferred":[
+        "Talaith B\u00e9ja\u00efa"
+    ],
     "name:dan_x_preferred":[
         "B\u00e9ja\u00efa"
+    ],
+    "name:dan_x_variant":[
+        "Bejaia"
     ],
     "name:deu_x_preferred":[
         "Bejaia"
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03b5\u03c4\u03b6\u03ac\u03b3\u03b9\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03c0\u03b5\u03c4\u03b6\u03ac\u03b3\u03b9\u03b1"
     ],
     "name:eng_x_preferred":[
         "B\u00e9jaia"
@@ -78,7 +88,8 @@
         "B\u00e9ja\u00efa",
         "B\u00e9ja\u00efa",
         "B\u00e9ja\u00efa Province",
-        "B\u00e9jaia Province"
+        "B\u00e9jaia Province",
+        "Bejaia Province"
     ],
     "name:epo_x_preferred":[
         "Provinco Be\u0135aja"
@@ -97,6 +108,9 @@
     ],
     "name:fra_x_variant":[
         "B\u00e9ja\u00efa"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Bejaia"
     ],
     "name:glg_x_preferred":[
         "Provincia de B\u00e9ja\u00efa"
@@ -221,8 +235,14 @@
     "name:war_x_preferred":[
         "B\u00e9ja\u00efa"
     ],
+    "name:wuu_x_preferred":[
+        "\u8d1d\u8d3e\u4e9a\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u8d1d\u8d3e\u4e9a\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Bejaia Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -344,7 +364,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807361,
+    "wof:lastmodified":1690875495,
     "wof:name":"B\u00e9jaia",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/19/85670819.geojson
+++ b/data/856/708/19/85670819.geojson
@@ -68,6 +68,9 @@
     "name:cym_x_preferred":[
         "Blida"
     ],
+    "name:cym_x_variant":[
+        "Talaith Blida"
+    ],
     "name:dan_x_preferred":[
         "Blida"
     ],
@@ -79,6 +82,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bb\u03af\u03bd\u03c4\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03c0\u03bb\u03b9\u03bd\u03c4\u03ac"
     ],
     "name:eng_x_preferred":[
         "Blida"
@@ -109,6 +115,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Blida"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Blida"
     ],
     "name:glg_x_preferred":[
         "Provincia de Blida"
@@ -287,11 +296,17 @@
     "name:war_x_preferred":[
         "Blida"
     ],
+    "name:wuu_x_preferred":[
+        "\u535c\u5229\u8fbe\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u535c\u5229\u8fbe"
     ],
     "name:zho_x_variant":[
         "\u535c\u5229\u8fbe\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Blida Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -416,7 +431,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501713,
+    "wof:lastmodified":1690875493,
     "wof:name":"Blida",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/23/85670823.geojson
+++ b/data/856/708/23/85670823.geojson
@@ -38,6 +38,9 @@
     "name:azb_x_preferred":[
         "\u0628\u0648\u06cc\u0631\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "Buira vilay\u0259ti"
+    ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u0411\u0443\u0456\u0440\u0430"
     ],
@@ -53,6 +56,9 @@
     "name:ceb_x_preferred":[
         "Bou\u00efra"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Bou\u00efra"
+    ],
     "name:dan_x_preferred":[
         "Bou\u00efra Province"
     ],
@@ -61,6 +67,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bf\u03c5\u03af\u03c1\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03c0\u03bf\u03c5\u03af\u03c1\u03b1"
     ],
     "name:eng_x_preferred":[
         "Bouira"
@@ -86,6 +95,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Bouira"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Bouira"
     ],
     "name:glg_x_preferred":[
         "Provincia de Bouira"
@@ -219,14 +231,23 @@
     "name:urd_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u0627\u0644\u0628\u0648\u06cc\u0631\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Buira viloyati"
+    ],
     "name:vie_x_preferred":[
         "Bouira"
     ],
     "name:war_x_preferred":[
         "Bou\u00efra"
     ],
+    "name:wuu_x_preferred":[
+        "\u5e03\u7ef4\u62c9\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5e03\u7ef4\u62c9\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Bou\u00efra Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -350,7 +371,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501714,
+    "wof:lastmodified":1690875495,
     "wof:name":"Bouira",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/27/85670827.geojson
+++ b/data/856/708/27/85670827.geojson
@@ -65,6 +65,9 @@
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03af\u03c3\u03ba\u03c1\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03c0\u03af\u03c3\u03ba\u03c1\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Biskra"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:fra_x_variant":[
         "Biskra"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Biskra"
     ],
     "name:glg_x_preferred":[
         "Provincia de Biskra"
@@ -218,8 +224,14 @@
     "name:war_x_preferred":[
         "Biskra"
     ],
+    "name:wuu_x_preferred":[
+        "\u6bd4\u65af\u514b\u62c9\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u6bd4\u65af\u514b\u62c9\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Biskra Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -340,7 +352,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501713,
+    "wof:lastmodified":1690875492,
     "wof:name":"Biskra",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/33/85670833.geojson
+++ b/data/856/708/33/85670833.geojson
@@ -53,6 +53,9 @@
     "name:ceb_x_preferred":[
         "Djelfa"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Djelfa"
+    ],
     "name:dan_x_preferred":[
         "Djelfa Province"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b6\u03ad\u03bb\u03c6\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b6\u03b5\u03bb\u03c6\u03ac"
     ],
     "name:eng_x_preferred":[
         "Djelfa"
@@ -91,6 +97,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Djelfa"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Djelfa"
     ],
     "name:glg_x_preferred":[
         "Provincia de Djelfa"
@@ -251,6 +260,9 @@
     "name:zho_x_variant":[
         "\u6770\u52d2\u6cd5\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Djelfa Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -373,7 +385,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501713,
+    "wof:lastmodified":1690875491,
     "wof:name":"Djelfa",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/37/85670837.geojson
+++ b/data/856/708/37/85670837.geojson
@@ -36,13 +36,17 @@
         "\u0627\u0644\u0645\u062f\u064a\u0629"
     ],
     "name:ara_x_variant":[
-        "Medea"
+        "Medea",
+        "\u0648\u0644\u0627\u064a\u0629 \u0627\u0644\u0645\u062f\u064a\u0629"
     ],
     "name:azb_x_preferred":[
         "\u0645\u062f\u06cc\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
     "name:aze_x_preferred":[
         "Medea"
+    ],
+    "name:aze_x_variant":[
+        "Medea vilay\u0259ti"
     ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u041c\u0435\u0434\u044d\u0430"
@@ -65,6 +69,9 @@
     "name:ceb_x_preferred":[
         "Wilaya de M\u00e9d\u00e9a"
     ],
+    "name:cym_x_preferred":[
+        "Talaith M\u00e9d\u00e9a"
+    ],
     "name:dan_x_preferred":[
         "M\u00e9d\u00e9a Province"
     ],
@@ -73,6 +80,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b5\u03bd\u03c4\u03ad\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03b5\u03bd\u03c4\u03ad\u03b1"
     ],
     "name:eng_x_preferred":[
         "Medea"
@@ -84,6 +94,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Medea"
+    ],
+    "name:eus_x_preferred":[
+        "Medeako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0645\u062f\u06cc\u0647"
@@ -97,6 +110,9 @@
     "name:fra_x_variant":[
         "wilaya de M\u00e9d\u00e9a",
         "M\u00e9d\u00e9a"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige M\u00e9d\u00e9a"
     ],
     "name:glg_x_preferred":[
         "Provincia de M\u00e9d\u00e9a"
@@ -212,6 +228,9 @@
     "name:urd_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u0627\u0644\u0645\u062f\u06cc\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Medea viloyati"
+    ],
     "name:vie_x_preferred":[
         "M\u00e9d\u00e9a"
     ],
@@ -220,6 +239,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9ea6\u8fea\u4e9a\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "M\u00e9d\u00e9a Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -341,7 +363,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807360,
+    "wof:lastmodified":1690875493,
     "wof:name":"Medea",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/41/85670841.geojson
+++ b/data/856/708/41/85670841.geojson
@@ -53,6 +53,9 @@
     "name:ceb_x_preferred":[
         "M'Sila"
     ],
+    "name:cym_x_preferred":[
+        "Talaith M'Sila"
+    ],
     "name:dan_x_preferred":[
         "M'Sila Province"
     ],
@@ -61,6 +64,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0395\u03bc\u03c3\u03af\u03bb\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c'\u03a3\u03b9\u03bb\u03ac"
     ],
     "name:eng_x_preferred":[
         "M'sila"
@@ -72,6 +78,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco M'Sila"
+    ],
+    "name:eus_x_preferred":[
+        "M'Silako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0645\u0633\u06cc\u0644\u0647\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -91,6 +100,9 @@
     "name:fra_x_variant":[
         "wilaya de M'Sila"
     ],
+    "name:gle_x_preferred":[
+        "C\u00faige M'Sila"
+    ],
     "name:glg_x_preferred":[
         "Provincia de M'Sila"
     ],
@@ -99,6 +111,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d0\u05dc-\u05de\u05e1\u05d9\u05dc\u05d4"
+    ],
+    "name:heb_x_variant":[
+        "\u05de\u05d7\u05d5\u05d6 \u05de\u05e1\u05d9\u05dc\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u092e'\u0938\u093f\u0932\u093e \u092a\u094d\u0930\u093e\u0902\u0924"
@@ -250,6 +265,9 @@
     "name:zho_x_variant":[
         "\u59c6\u897f\u62c9\u7701"
     ],
+    "name:zul_x_preferred":[
+        "M'Sila Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -368,7 +386,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501714,
+    "wof:lastmodified":1690875494,
     "wof:name":"M'sila",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/45/85670845.geojson
+++ b/data/856/708/45/85670845.geojson
@@ -33,7 +33,8 @@
         "\u0633\u0637\u064a\u0641"
     ],
     "name:ara_x_variant":[
-        "Setif"
+        "Setif",
+        "\u0648\u0644\u0627\u064a\u0629 \u0633\u0637\u064a\u0641"
     ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u0421\u0435\u0442\u044b\u0444"
@@ -53,6 +54,9 @@
     "name:ceb_x_preferred":[
         "Wilaya de S\u00e9tif"
     ],
+    "name:cym_x_preferred":[
+        "Talaith S\u00e9tif"
+    ],
     "name:dan_x_preferred":[
         "S\u00e9tif Province"
     ],
@@ -61,6 +65,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03b5\u03c4\u03af\u03c6"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a3\u03b5\u03c4\u03af\u03c6"
     ],
     "name:eng_x_preferred":[
         "S\u00e9tif"
@@ -73,6 +80,9 @@
     ],
     "name:est_x_preferred":[
         "S\u00e9tifi provints"
+    ],
+    "name:eus_x_preferred":[
+        "Setifeko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0633\u0637\u06cc\u0641"
@@ -88,6 +98,9 @@
     ],
     "name:fra_x_variant":[
         "S\u00e9tif"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige S\u00e9tif"
     ],
     "name:glg_x_preferred":[
         "Provincia de S\u00e9tif"
@@ -215,6 +228,9 @@
     "name:zho_x_preferred":[
         "\u585e\u63d0\u592b\u7701"
     ],
+    "name:zul_x_preferred":[
+        "S\u00e9tif Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -335,7 +351,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807360,
+    "wof:lastmodified":1690875492,
     "wof:name":"S\u00e9tif",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/51/85670851.geojson
+++ b/data/856/708/51/85670851.geojson
@@ -56,6 +56,9 @@
     "name:cat_x_preferred":[
         "Prov\u00edncia de Batna"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Batna"
+    ],
     "name:dan_x_preferred":[
         "Batna"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03ac\u03c4\u03bd\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03c0\u03ac\u03c4\u03bd\u03b1"
     ],
     "name:eng_x_preferred":[
         "Batna"
@@ -89,6 +95,12 @@
     "name:fra_x_variant":[
         "Wilaya de Batna",
         "wilaya de Batna"
+    ],
+    "name:frr_x_preferred":[
+        "Batna"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Batna"
     ],
     "name:glg_x_preferred":[
         "Provincia de Batna"
@@ -116,6 +128,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d0\u30c8\u30ca\u770c"
+    ],
+    "name:kab_x_preferred":[
+        "Batna"
     ],
     "name:kan_x_preferred":[
         "\u0cac\u0c9f\u0ccd\u0ca8\u0cbe \u0caa\u0ccd\u0cb0\u0cbe\u0c82\u0ca4\u0ccd\u0caf"
@@ -225,8 +240,14 @@
     "name:war_x_preferred":[
         "Batna"
     ],
+    "name:wuu_x_preferred":[
+        "\u5df4\u7279\u7eb3\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u5df4\u7279\u7eb3\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Batna Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -348,7 +369,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501712,
+    "wof:lastmodified":1690875491,
     "wof:name":"Batna",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/55/85670855.geojson
+++ b/data/856/708/55/85670855.geojson
@@ -38,6 +38,9 @@
     "name:azb_x_preferred":[
         "\u0642\u0633\u0646\u0637\u06cc\u0646\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "Q\u00fcs\u0259ntin\u0259 vilay\u0259ti"
+    ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u041a\u0430\u043d\u0441\u0442\u0430\u043d\u0446\u0456\u043d\u0430"
     ],
@@ -59,6 +62,9 @@
     "name:cym_x_preferred":[
         "Constantine"
     ],
+    "name:cym_x_variant":[
+        "Talaith Constantine"
+    ],
     "name:dan_x_preferred":[
         "Constantine"
     ],
@@ -74,6 +80,9 @@
     "name:ell_x_preferred":[
         "\u039a\u03c9\u03bd\u03c3\u03c4\u03b1\u03bd\u03c4\u03af\u03bd\u03b7"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039a\u03c9\u03bd\u03c3\u03c4\u03b1\u03bd\u03c4\u03af\u03bd\u03b7\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Constantine"
     ],
@@ -82,6 +91,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Konstantina"
+    ],
+    "name:eus_x_preferred":[
+        "Konstantinako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0642\u0633\u0646\u0637\u06cc\u0646\u0647"
@@ -98,6 +110,12 @@
     "name:fra_x_variant":[
         "wilaya de Constantine"
     ],
+    "name:frr_x_preferred":[
+        "Constantine"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Constantine"
+    ],
     "name:glg_x_preferred":[
         "Provincia de Constantina"
     ],
@@ -112,6 +130,9 @@
     ],
     "name:hun_x_preferred":[
         "Constantine"
+    ],
+    "name:hun_x_variant":[
+        "Kaszent\u00edna tartom\u00e1ny"
     ],
     "name:ind_x_preferred":[
         "Provinsi Qusnathinah"
@@ -130,6 +151,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10d9\u10dd\u10dc\u10e1\u10e2\u10d0\u10dc\u10e2\u10d8\u10dc\u10d8\u10e1 \u10de\u10e0\u10dd\u10d5\u10d8\u10dc\u10ea\u10d8\u10d0"
+    ],
+    "name:kaz_x_preferred":[
+        "\u049a\u0443\u0441\u0430\u043d\u0442\u0438\u044f \u0443\u04d9\u043b\u0430\u044f\u0442\u044b"
     ],
     "name:kor_x_preferred":[
         "\ucf58\uc2a4\ud134\ud2f4"
@@ -236,6 +260,9 @@
     "name:urd_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u0642\u0633\u0646\u0637\u06cc\u0646\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Qusantina viloyati"
+    ],
     "name:vie_x_preferred":[
         "Constantine"
     ],
@@ -247,6 +274,9 @@
     ],
     "name:zho_x_preferred":[
         "\u541b\u58eb\u5766\u4e01\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Constantine Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -368,7 +398,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501714,
+    "wof:lastmodified":1690875494,
     "wof:name":"Constantine",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/57/85670857.geojson
+++ b/data/856/708/57/85670857.geojson
@@ -38,6 +38,9 @@
     "name:azb_x_preferred":[
         "\u0642\u0627\u0644\u0645\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
+    "name:aze_x_preferred":[
+        "Qelma vilay\u0259ti"
+    ],
     "name:bel_x_preferred":[
         "\u041f\u0440\u0430\u0432\u0456\u043d\u0446\u044b\u044f \u0413\u0435\u043b\u044c\u043c\u0430"
     ],
@@ -56,6 +59,9 @@
     "name:ceb_x_preferred":[
         "Guelma"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Guelma"
+    ],
     "name:dan_x_preferred":[
         "Guelma Province"
     ],
@@ -64,6 +70,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03ba\u03ad\u03bb\u03bc\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u0393\u03ba\u03b5\u03bb\u03bc\u03ac"
     ],
     "name:eng_x_preferred":[
         "Guelma"
@@ -76,6 +85,9 @@
     ],
     "name:epo_x_variant":[
         "Provinco Gelma"
+    ],
+    "name:eus_x_preferred":[
+        "Guelmako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0642\u0627\u0644\u0645\u0647\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -91,6 +103,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Guelma"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Guelma"
     ],
     "name:glg_x_preferred":[
         "Provincia de Guelma"
@@ -251,6 +266,9 @@
     "name:zho_x_variant":[
         "\u76d6\u52d2\u9a6c\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Guelma Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -371,7 +389,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501712,
+    "wof:lastmodified":1690875491,
     "wof:name":"Guelma",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/61/85670861.geojson
+++ b/data/856/708/61/85670861.geojson
@@ -59,6 +59,9 @@
     "name:ceb_x_preferred":[
         "Khenchela"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Khenchela"
+    ],
     "name:dan_x_preferred":[
         "Khenchela"
     ],
@@ -68,6 +71,9 @@
     "name:ell_x_preferred":[
         "\u03a7\u03b5\u03bd\u03c3\u03ad\u03bb\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a7\u03b5\u03bd\u03c3\u03ad\u03bb\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Khenchela"
     ],
@@ -76,6 +82,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco \u0124en\u015dela"
+    ],
+    "name:eus_x_preferred":[
+        "Khenchelako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u062e\u0646\u0634\u0644\u0647\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -91,6 +100,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Khenchela"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Khenchela"
     ],
     "name:glg_x_preferred":[
         "Provincia de Khenchela"
@@ -242,6 +254,9 @@
     "name:urd_x_variant":[
         "\u0635\u0648\u0628\u06c1 \u062e\u0646\u0634\u0644\u06c1"
     ],
+    "name:uzb_x_preferred":[
+        "Khenchela viloyati"
+    ],
     "name:vie_x_preferred":[
         "Khenchela"
     ],
@@ -253,6 +268,9 @@
     ],
     "name:zho_x_variant":[
         "\u6c49\u820d\u83b1\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Khenchela Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -376,7 +394,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501712,
+    "wof:lastmodified":1690875490,
     "wof:name":"Khenchela",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/67/85670867.geojson
+++ b/data/856/708/67/85670867.geojson
@@ -50,6 +50,9 @@
     "name:cat_x_preferred":[
         "Prov\u00edncia de Mila"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Mila"
+    ],
     "name:dan_x_preferred":[
         "Mila Province"
     ],
@@ -59,6 +62,9 @@
     "name:ell_x_preferred":[
         "\u039c\u03af\u03bb\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039c\u03af\u03bb\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Mila"
     ],
@@ -67,6 +73,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Mila"
+    ],
+    "name:eus_x_preferred":[
+        "Milako probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0645\u06cc\u0644\u0647"
@@ -79,6 +88,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Mila"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Mila"
     ],
     "name:glg_x_preferred":[
         "Provincia de Mila"
@@ -121,6 +133,9 @@
     ],
     "name:lad_x_preferred":[
         "Wilaya de Mila"
+    ],
+    "name:lat_x_preferred":[
+        "Milevum"
     ],
     "name:lav_x_preferred":[
         "M\u012blas vil\u0101ja"
@@ -173,6 +188,9 @@
     "name:rus_x_preferred":[
         "\u041c\u0438\u043b\u0430"
     ],
+    "name:sco_x_preferred":[
+        "Mila"
+    ],
     "name:sin_x_preferred":[
         "\u0db8\u0dd2\u0dbd\u0dcf \u0db4\u0dc5\u0dcf\u0dad"
     ],
@@ -223,6 +241,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7c73\u62c9\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Mila Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -344,7 +365,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501713,
+    "wof:lastmodified":1690875491,
     "wof:name":"Mila",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/71/85670871.geojson
+++ b/data/856/708/71/85670871.geojson
@@ -39,6 +39,9 @@
     "name:ast_x_preferred":[
         "Provincia d'Oum el-Bouaghi"
     ],
+    "name:ast_x_variant":[
+        "provincia d'Oum el-Bouaghi"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0645\u200c\u0627\u0644\u0628\u0648\u0627\u0642\u06cc \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
     ],
@@ -57,6 +60,9 @@
     "name:ceb_x_preferred":[
         "Oum el Bouaghi"
     ],
+    "name:cym_x_preferred":[
+        "Talaith Oum El Bouaghi"
+    ],
     "name:dan_x_preferred":[
         "Oum El Bouaghi Province"
     ],
@@ -65,6 +71,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039f\u03c5\u03bc \u0395\u03bb \u039c\u03c0\u03bf\u03c5\u03ac\u03b3\u03b9"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u039f\u03c5\u03bc \u0395\u03bb \u039c\u03c0\u03bf\u03c5\u03b1\u03b3\u03ba\u03af"
     ],
     "name:eng_x_preferred":[
         "Oum el Bouaghi"
@@ -90,6 +99,9 @@
     ],
     "name:fra_x_variant":[
         "Oum El Bouaghi"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Oum El Bouaghi"
     ],
     "name:glg_x_preferred":[
         "Provincia de Oum El Bouaghi"
@@ -181,6 +193,9 @@
     "name:tam_x_preferred":[
         "\u0b93\u0bae\u0bcd  \u0b8e\u0bb2\u0bcd \u0baa\u0bcc\u0b85\u0b83\u0bb9\u0bbf \u0bae\u0bbe\u0b95\u0bbe\u0ba3\u0bae\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0b93\u0bae\u0bcd \u0b8e\u0bb2\u0bcd \u0baa\u0bcc\u0b85\u0b83\u0bb9\u0bbf \u0bae\u0bbe\u0b95\u0bbe\u0ba3\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c13\u0c35\u0c2e\u0c4d \u0c0e\u0c32\u0c4d \u0c2c\u0c4a\u0c35\u0c3e\u0c18\u0c40 \u0c2a\u0c4d\u0c30\u0c3e\u0c35\u0c3f\u0c28\u0c4d\u0c38\u0c4d"
     ],
@@ -214,8 +229,14 @@
     "name:war_x_preferred":[
         "Oum el-Bouaghi"
     ],
+    "name:wuu_x_preferred":[
+        "\u4e4c\u59c6\u5e03\u74e6\u5409\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u4e4c\u59c6\u5e03\u74e6\u5409\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Oum El Bouaghi Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -337,7 +358,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501714,
+    "wof:lastmodified":1690875495,
     "wof:name":"Oum el Bouaghi",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/75/85670875.geojson
+++ b/data/856/708/75/85670875.geojson
@@ -56,6 +56,9 @@
     "name:cym_x_preferred":[
         "Souk-Ahras"
     ],
+    "name:cym_x_variant":[
+        "Talaith Souk Ahras"
+    ],
     "name:dan_x_preferred":[
         "Souk Ahras Province"
     ],
@@ -68,6 +71,9 @@
     "name:ell_x_preferred":[
         "\u03a3\u03bf\u03c5\u03ba \u0391\u03c7\u03c1\u03ac\u03c2"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a3\u03bf\u03c5\u03ba \u0391\u03c7\u03c1\u03ac\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Souk Ahras"
     ],
@@ -76,6 +82,9 @@
     ],
     "name:epo_x_preferred":[
         "Provinco Suk Ahras"
+    ],
+    "name:eus_x_preferred":[
+        "Souk Ahrasko probintzia"
     ],
     "name:fas_x_preferred":[
         "\u0633\u0648\u0642 \u0627\u0647\u0631\u0627\u0633\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -91,6 +100,9 @@
     ],
     "name:fra_x_variant":[
         "wilaya de Souk Ahras"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige Souk Ahras"
     ],
     "name:glg_x_preferred":[
         "Provincia de Souk Ahras"
@@ -257,6 +269,9 @@
     "name:zho_x_variant":[
         "\u82cf\u683c\u827e\u8d6b\u62c9\u65af\u7701"
     ],
+    "name:zul_x_preferred":[
+        "Souk Ahras Province"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
     "ne:adm0_label":"2",
@@ -377,7 +392,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1636501713,
+    "wof:lastmodified":1690875493,
     "wof:name":"Souk Ahras",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/79/85670879.geojson
+++ b/data/856/708/79/85670879.geojson
@@ -33,7 +33,8 @@
         "\u062a\u0628\u0633\u0629"
     ],
     "name:ara_x_variant":[
-        "Tebessa"
+        "Tebessa",
+        "\u0648\u0644\u0627\u064a\u0629 \u062a\u0628\u0633\u0629"
     ],
     "name:azb_x_preferred":[
         "\u062a\u0628\u0633\u0647 \u0627\u0648\u0633\u062a\u0627\u0646\u06cc"
@@ -56,6 +57,9 @@
     "name:ceb_x_preferred":[
         "Wilaya de T\u00e9bessa"
     ],
+    "name:cym_x_preferred":[
+        "Talaith T\u00e9bessa"
+    ],
     "name:dan_x_preferred":[
         "T\u00e9bessa Province"
     ],
@@ -64,6 +68,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b5\u03bc\u03c0\u03ad\u03c3\u03c3\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03c0\u03b1\u03c1\u03c7\u03af\u03b1 \u03a4\u03b5\u03bc\u03c0\u03ad\u03c3\u03b1"
     ],
     "name:eng_x_preferred":[
         "T\u00e9bessa"
@@ -88,6 +95,9 @@
     ],
     "name:fra_x_variant":[
         "T\u00e9bessa"
+    ],
+    "name:gle_x_preferred":[
+        "C\u00faige T\u00e9bessa"
     ],
     "name:glg_x_preferred":[
         "Provincia de T\u00e9bessa"
@@ -203,8 +213,14 @@
     "name:war_x_preferred":[
         "T\u00e9bessa"
     ],
+    "name:wuu_x_preferred":[
+        "\u6cf0\u8d1d\u8428\u7701"
+    ],
     "name:zho_x_preferred":[
         "\u6cf0\u8d1d\u8428\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Tebessa Province"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DZA",
@@ -326,7 +342,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1614807361,
+    "wof:lastmodified":1690875494,
     "wof:name":"T\u00e9bessa",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/858/021/19/85802119.geojson
+++ b/data/858/021/19/85802119.geojson
@@ -33,11 +33,17 @@
         "Alger Bab El Oued",
         "Faubourg Bab el Oued"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0628 \u0627\u0644\u0648\u0627\u062f\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0627\u0628 \u0648\u0627\u062f\u06cc"
     ],
     "name:cat_x_preferred":[
         "Bab El-Oued"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b1\u03bc\u03c0 \u0395\u03bb \u039f\u03c5\u03ad\u03bd\u03c4"
     ],
     "name:eng_x_preferred":[
         "Bab El Oued"
@@ -80,6 +86,12 @@
     ],
     "name:spa_x_preferred":[
         "Bab El Oued"
+    ],
+    "name:swe_x_preferred":[
+        "Bab El Oued"
+    ],
+    "name:tur_x_preferred":[
+        "Bab\u00fc'l-Vadi"
     ],
     "name:urd_x_preferred":[
         "\u0628\u0627\u0628 \u0627\u0644\u0648\u0627\u062f\u06cc"
@@ -155,7 +167,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582348637,
+    "wof:lastmodified":1690875504,
     "wof:name":"Bab el Oued",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/35/85802135.geojson
+++ b/data/858/021/35/85802135.geojson
@@ -33,8 +33,17 @@
         "El Biar Cour Supreme",
         "\u0628\u0644\u062f\u064a\u0629 \u0627\u0644\u0623\u0628\u064a\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0627\u0628\u064a\u0627\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0628\u06cc\u0627\u0631"
+    ],
+    "name:aze_x_preferred":[
+        "El-Biar"
+    ],
+    "name:bar_x_preferred":[
+        "El Biar"
     ],
     "name:cat_x_preferred":[
         "El Biar"
@@ -60,6 +69,9 @@
     "name:fra_x_preferred":[
         "El Biar"
     ],
+    "name:gle_x_preferred":[
+        "El Biar"
+    ],
     "name:glg_x_preferred":[
         "El-Biar"
     ],
@@ -68,6 +80,9 @@
     ],
     "name:ita_x_preferred":[
         "El-Biar"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a8\u30eb\u30fb\u30d3\u30a2\u30eb"
     ],
     "name:kab_x_preferred":[
         "Lebyar"
@@ -98,6 +113,9 @@
     ],
     "name:swe_x_preferred":[
         "El Biar"
+    ],
+    "name:tur_x_preferred":[
+        "El-Abyar"
     ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u0627\u0628\u06cc\u0627\u0631"
@@ -165,7 +183,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582348637,
+    "wof:lastmodified":1690875503,
     "wof:name":"El Biar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/41/85802141.geojson
+++ b/data/858/021/41/85802141.geojson
@@ -36,11 +36,17 @@
         "El Harrach 5 Maisons",
         "Maison Carr\u00e9e"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u0631\u0627\u0634"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u062d\u0631\u0627\u0634"
     ],
     "name:deu_x_preferred":[
         "El-Harrach"
+    ],
+    "name:ell_x_preferred":[
+        "\u0395\u03bb \u03a7\u03b1\u03c1\u03ac\u03c2"
     ],
     "name:eng_x_preferred":[
         "El Harrach"
@@ -83,6 +89,9 @@
     ],
     "name:spa_x_preferred":[
         "El Harrach"
+    ],
+    "name:tur_x_preferred":[
+        "El-Harra\u015f"
     ],
     "name:urd_x_preferred":[
         "\u0627\u0644\u062d\u0631\u0627\u0634"
@@ -155,7 +164,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582348638,
+    "wof:lastmodified":1690875504,
     "wof:name":"El Harrach",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/49/85802149.geojson
+++ b/data/858/021/49/85802149.geojson
@@ -36,6 +36,9 @@
         "Husseini Dey",
         "Ruisseau"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0635\u0631 \u062d\u0633\u064a\u0646 \u062f\u0627\u0649"
+    ],
     "name:cat_x_preferred":[
         "Nasr Athl\u00e9tique de Hussein Dey"
     ],
@@ -66,13 +69,25 @@
     "name:ita_x_preferred":[
         "Nasr Athl\u00e9tique de Hussein Dey"
     ],
+    "name:ita_x_variant":[
+        "NA Hussein Dey"
+    ],
     "name:nld_x_preferred":[
         "NA Hussein Dey"
     ],
     "name:pol_x_preferred":[
         "NA Hussein Dey"
     ],
+    "name:por_x_preferred":[
+        "NA Hussein Dey"
+    ],
+    "name:ron_x_preferred":[
+        "NA Hussein Dey"
+    ],
     "name:spa_x_preferred":[
+        "NA Hussein Dey"
+    ],
+    "name:tur_x_preferred":[
         "NA Hussein Dey"
     ],
     "name:ukr_x_preferred":[
@@ -138,7 +153,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582348638,
+    "wof:lastmodified":1690875504,
     "wof:name":"Husse\u00efn Dey",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/53/85802153.geojson
+++ b/data/858/021/53/85802153.geojson
@@ -38,6 +38,9 @@
     "name:ces_x_preferred":[
         "Kasba"
     ],
+    "name:dan_x_preferred":[
+        "Kasbah"
+    ],
     "name:deu_x_preferred":[
         "Kasbah"
     ],
@@ -68,8 +71,17 @@
     "name:hrv_x_preferred":[
         "Kazba"
     ],
+    "name:hsb_x_preferred":[
+        "kasbah"
+    ],
     "name:hun_x_preferred":[
         "Kasbah"
+    ],
+    "name:hun_x_variant":[
+        "kaszba"
+    ],
+    "name:ido_x_preferred":[
+        "Kasba"
     ],
     "name:ind_x_preferred":[
         "Kasbah"
@@ -77,8 +89,14 @@
     "name:ita_x_preferred":[
         "Qasba"
     ],
+    "name:ita_x_variant":[
+        "casba"
+    ],
     "name:jpn_x_preferred":[
         "\u30ab\u30b9\u30d0"
+    ],
+    "name:msa_x_preferred":[
+        "Qasabah"
     ],
     "name:nld_x_preferred":[
         "Kasba"
@@ -113,10 +131,16 @@
     "name:slv_x_preferred":[
         "Kasbah"
     ],
+    "name:spa_x_preferred":[
+        "qasbah"
+    ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0437\u0431\u0430"
     ],
     "name:swe_x_preferred":[
+        "Kasbah"
+    ],
+    "name:tur_x_preferred":[
         "Kasbah"
     ],
     "name:ukr_x_preferred":[
@@ -192,7 +216,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582348637,
+    "wof:lastmodified":1690875504,
     "wof:name":"Kasbah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/414/789/890414789.geojson
+++ b/data/890/414/789/890414789.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u062c\u0628\u064a\u0644\u0629 \u0627\u0644\u0631\u0635\u0641\u0627\u0621"
     ],
+    "name:ara_x_variant":[
+        "\u062c\u0628\u064a\u0644\u0627\u062a \u0627\u0644\u0631\u0635\u0641\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u0628\u064a\u0644\u0647 \u0627\u0644\u0631\u0635\u0641\u0627\u0621"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u0628\u06cc\u0644\u0647 \u0631\u0635\u0641\u0627\u0621"
     ],
@@ -39,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Djebilet Rosfa"
+    ],
+    "name:kab_x_preferred":[
+        "\u01e6bilat Rre\u1e63fa"
     ],
     "name:msa_x_preferred":[
         "Djebilet Rosfa"
@@ -66,6 +75,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5091\u6bd4\u840a\u7279\u7f85\u65af\u6cd5"
+    ],
+    "name:zul_x_preferred":[
+        "Djebilet Rosfa"
     ],
     "qs:name":"Djebilet Rosfa",
     "qs:photos_9r":0,
@@ -98,7 +110,7 @@
         }
     ],
     "wof:id":890414789,
-    "wof:lastmodified":1566583508,
+    "wof:lastmodified":1690875541,
     "wof:name":"Djebilet Rosfa",
     "wof:parent_id":85670801,
     "wof:placetype":"locality",

--- a/data/890/417/881/890417881.geojson
+++ b/data/890/417/881/890417881.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0639\u0632\u0627\u0628\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u0632\u0627\u0628\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0632\u0627\u0628\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Azzaba"
+    ],
+    "name:ceb_x_preferred":[
+        "Azzaba"
     ],
     "name:eng_x_preferred":[
         "Azzaba"
@@ -55,7 +64,16 @@
     "name:ron_x_preferred":[
         "Azzaba"
     ],
+    "name:rus_x_preferred":[
+        "\u0410\u0437\u0437\u0430\u0431\u0430"
+    ],
     "name:spa_x_preferred":[
+        "Azzaba"
+    ],
+    "name:swa_x_preferred":[
+        "Azzaba"
+    ],
+    "name:swe_x_preferred":[
         "Azzaba"
     ],
     "name:und_x_variant":[
@@ -98,7 +116,7 @@
         }
     ],
     "wof:id":890417881,
-    "wof:lastmodified":1566583510,
+    "wof:lastmodified":1690875546,
     "wof:name":"Azzaba",
     "wof:parent_id":85670727,
     "wof:placetype":"locality",

--- a/data/890/420/423/890420423.geojson
+++ b/data/890/420/423/890420423.geojson
@@ -22,10 +22,19 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0642\u0627\u0644\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0642\u0627\u0644\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "El Kala"
+    ],
     "name:cat_x_preferred":[
         "El Kala"
     ],
     "name:ceb_x_preferred":[
+        "El Kala"
+    ],
+    "name:dan_x_preferred":[
         "El Kala"
     ],
     "name:deu_x_preferred":[
@@ -48,11 +57,17 @@
         "Port de la Calle",
         "El Kala"
     ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05dc-\u05e7\u05d0\u05dc\u05d4"
+    ],
     "name:hun_x_preferred":[
         "Al-K\u00e1la"
     ],
     "name:ita_x_preferred":[
         "El Kala"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a8\u30eb\u30fb\u30ab\u30e9"
     ],
     "name:kab_x_preferred":[
         "Lqala"
@@ -83,6 +98,9 @@
     ],
     "name:swe_x_preferred":[
         "El Kala"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0415\u043b\u044c-\u041a\u0430\u043b\u0430"
     ],
     "name:vie_x_preferred":[
         "El Kala"
@@ -121,7 +139,7 @@
         }
     ],
     "wof:id":890420423,
-    "wof:lastmodified":1566583515,
+    "wof:lastmodified":1690875550,
     "wof:name":"El Kala",
     "wof:parent_id":85670719,
     "wof:placetype":"locality",

--- a/data/890/422/509/890422509.geojson
+++ b/data/890/422/509/890422509.geojson
@@ -46,6 +46,9 @@
     "name:ita_x_preferred":[
         "Al-Mansura"
     ],
+    "name:kab_x_preferred":[
+        "Lmen\u1e63ura"
+    ],
     "name:nan_x_preferred":[
         "Mansourah"
     ],
@@ -72,6 +75,12 @@
     ],
     "name:urd_x_variant":[
         "\u0645\u0646\u0635\u0648\u0631\u06c1"
+    ],
+    "name:uzb_x_preferred":[
+        "Mansur"
+    ],
+    "name:zul_x_preferred":[
+        "Mansoura"
     ],
     "qs:name":"Manso\u00fbra",
     "qs:photos_9r":0,
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":890422509,
-    "wof:lastmodified":1566583507,
+    "wof:lastmodified":1690875541,
     "wof:name":"Manso\u00fbra",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/890/422/511/890422511.geojson
+++ b/data/890/422/511/890422511.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u062c\u0627\u0645\u0639\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0627\u0645\u0639\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u0627\u0645\u0639\u0647"
     ],
@@ -37,8 +40,14 @@
     "name:fra_x_preferred":[
         "Djamaa"
     ],
+    "name:hau_x_preferred":[
+        "Djamaa"
+    ],
     "name:ita_x_preferred":[
         "Djamaa"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b8\u30e3\u30de\u30fc"
     ],
     "name:msa_x_preferred":[
         "Djamaa"
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":890422511,
-    "wof:lastmodified":1566583507,
+    "wof:lastmodified":1690875541,
     "wof:name":"Djamaa",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",

--- a/data/890/429/573/890429573.geojson
+++ b/data/890/429/573/890429573.geojson
@@ -61,6 +61,9 @@
     "name:und_x_variant":[
         "Sidi Bou Hanifia"
     ],
+    "name:uzb_x_preferred":[
+        "Bou Hanifiya"
+    ],
     "qs:name":"Bou Hanifia el Hamamat",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890429573,
-    "wof:lastmodified":1566583514,
+    "wof:lastmodified":1690875549,
     "wof:name":"Bou Hanifia el Hamamat",
     "wof:parent_id":85670785,
     "wof:placetype":"locality",

--- a/data/890/429/575/890429575.geojson
+++ b/data/890/429/575/890429575.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u062c\u064a\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u062c\u064a\u0645\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u062c\u06cc\u0645\u0647"
     ],
@@ -70,6 +73,9 @@
     "name:zho_x_preferred":[
         "\u5e03\u5409\u99ac"
     ],
+    "name:zul_x_preferred":[
+        "Boudjima"
+    ],
     "qs:name":"Boudjima",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":890429575,
-    "wof:lastmodified":1566583514,
+    "wof:lastmodified":1690875549,
     "wof:name":"Boudjima",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/890/432/317/890432317.geojson
+++ b/data/890/432/317/890432317.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062d\u062c\u064a\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u062c\u064a\u0631\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062d\u062c\u06cc\u0631\u0647"
     ],
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":890432317,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1690875553,
     "wof:name":"El Hadjira",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",

--- a/data/890/432/319/890432319.geojson
+++ b/data/890/432/319/890432319.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_variant":[
         "\u062f\u0644\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0644\u0633"
+    ],
+    "name:aze_x_preferred":[
+        "Dellis"
+    ],
     "name:cat_x_preferred":[
         "Dellys"
     ],
@@ -32,6 +38,12 @@
         "Dellys"
     ],
     "name:cym_x_preferred":[
+        "Dellys"
+    ],
+    "name:dan_x_preferred":[
+        "Dellys"
+    ],
+    "name:deu_x_preferred":[
         "Dellys"
     ],
     "name:eng_x_preferred":[
@@ -76,11 +88,17 @@
     "name:spa_x_preferred":[
         "Dellys"
     ],
+    "name:swa_x_preferred":[
+        "Dellys"
+    ],
     "name:swe_x_preferred":[
         "Dellys"
     ],
     "name:und_x_variant":[
         "Delis"
+    ],
+    "name:urd_x_preferred":[
+        "\u062f\u0644\u0633"
     ],
     "name:vie_x_preferred":[
         "Dellys"
@@ -115,7 +133,7 @@
         }
     ],
     "wof:id":890432319,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1690875554,
     "wof:name":"Dellys",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/432/321/890432321.geojson
+++ b/data/890/432/321/890432321.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062f\u0628\u064a\u0644\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062f\u0628\u064a\u0644\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u0628\u06cc\u0644\u0647"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Distretto di Debila"
+    ],
+    "name:kab_x_preferred":[
+        "Ddbila"
     ],
     "name:msa_x_preferred":[
         "Debila"
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":890432321,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1690875554,
     "wof:name":"Debila",
     "wof:parent_id":85670745,
     "wof:placetype":"locality",

--- a/data/890/432/327/890432327.geojson
+++ b/data/890/432/327/890432327.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0634\u062a\u0648\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u062a\u0648\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u062a\u0648\u0627\u0646"
     ],
@@ -67,7 +70,13 @@
     "name:und_x_variant":[
         "N\u00e9grier"
     ],
+    "name:uzb_x_preferred":[
+        "Chetouane"
+    ],
     "name:vie_x_preferred":[
+        "Chetouane"
+    ],
+    "name:zul_x_preferred":[
         "Chetouane"
     ],
     "qs:name":"Chetouane",
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":890432327,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1690875553,
     "wof:name":"Chetouane",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/890/432/329/890432329.geojson
+++ b/data/890/432/329/890432329.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0631\u064a\u0639\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0631\u064a\u0639\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0631\u06cc\u0639\u0647"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "Cheria"
+    ],
+    "name:kab_x_preferred":[
+        "Ccri\u025ba"
     ],
     "name:msa_x_preferred":[
         "Cheria"
@@ -61,11 +67,20 @@
     "name:spa_x_preferred":[
         "Cheria"
     ],
+    "name:swa_x_preferred":[
+        "Cheria"
+    ],
     "name:swe_x_preferred":[
         "Cheria"
     ],
+    "name:uzb_x_preferred":[
+        "Cheriya"
+    ],
     "name:zho_x_preferred":[
         "\u820d\u91cc\u8036"
+    ],
+    "name:zul_x_preferred":[
+        "Cheria"
     ],
     "qs:name":"Cheria",
     "qs:photos_9r":0,
@@ -98,7 +113,7 @@
         }
     ],
     "wof:id":890432329,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1690875553,
     "wof:name":"Cheria",
     "wof:parent_id":85670879,
     "wof:placetype":"locality",

--- a/data/890/432/331/890432331.geojson
+++ b/data/890/432/331/890432331.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0626\u0631 \u0627\u0644\u0639\u0627\u062a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0626\u0631 \u0627\u0644\u0639\u0627\u062a\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0626\u0631 \u0639\u0627\u062a\u0631"
     ],
@@ -42,6 +45,12 @@
     ],
     "name:ita_x_preferred":[
         "Bir el-Ater"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d3\u30eb\u30fb\u30a8\u30eb\u30fb\u30a2\u30c6\u30eb"
+    ],
+    "name:kab_x_preferred":[
+        "Bir L\u025bater"
     ],
     "name:msa_x_preferred":[
         "Bir El Ater"
@@ -64,6 +73,9 @@
     "name:spa_x_preferred":[
         "Bir el-Ater"
     ],
+    "name:swa_x_preferred":[
+        "Bir el Ater"
+    ],
     "name:swe_x_preferred":[
         "Bir el Ater"
     ],
@@ -72,6 +84,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6bd4\u723e\u963f\u63d0\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Bir El Ater"
     ],
     "qs:name":"Bir el Ater",
     "qs:photos_9r":0,
@@ -104,7 +119,7 @@
         }
     ],
     "wof:id":890432331,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875552,
     "wof:name":"Bir el Ater",
     "wof:parent_id":85670879,
     "wof:placetype":"locality",

--- a/data/890/432/333/890432333.geojson
+++ b/data/890/432/333/890432333.geojson
@@ -22,11 +22,23 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u0631\u0648\u0627\u0642\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0628\u0631\u0648\u0627\u0642\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u0648\u0627\u0642\u06cc\u0647"
     ],
+    "name:aze_x_preferred":[
+        "Berruagiya"
+    ],
+    "name:cat_x_preferred":[
+        "Berrouaghia"
+    ],
     "name:ceb_x_preferred":[
         "Berrouaghia"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03c1\u03bf\u03c5\u03b1\u03b3\u03ba\u03b9\u03ac"
     ],
     "name:eng_x_preferred":[
         "Berrouaghia"
@@ -70,11 +82,17 @@
     "name:spa_x_preferred":[
         "Berrouaghia"
     ],
+    "name:swa_x_preferred":[
+        "Berrouaghia"
+    ],
     "name:swe_x_preferred":[
         "Berrouaghia"
     ],
     "name:und_x_variant":[
         "Berrouarhia"
+    ],
+    "name:uzb_x_preferred":[
+        "Berrouaghia"
     ],
     "name:vie_x_preferred":[
         "Berrouaghia"
@@ -113,7 +131,7 @@
         }
     ],
     "wof:id":890432333,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875553,
     "wof:name":"Berrouaghia",
     "wof:parent_id":85670837,
     "wof:placetype":"locality",

--- a/data/890/432/335/890432335.geojson
+++ b/data/890/432/335/890432335.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
     ],
+    "name:arq_x_preferred":[
+        "\u0639\u064a\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fyn-T\u0259m\u00fc\u015f\u0259nt"
     ],
     "name:cat_x_preferred":[
         "A\u00efn T\u00e9mouchent"
@@ -34,14 +43,29 @@
     "name:eng_x_preferred":[
         "A\u00efn T\u00e9mouchent"
     ],
+    "name:eus_x_preferred":[
+        "A\u00efn T\u00e9mouchent"
+    ],
     "name:fas_x_preferred":[
         "\u0639\u06cc\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
+    ],
+    "name:fin_x_preferred":[
+        "A\u00efn T\u00e9mouchent"
     ],
     "name:fra_x_preferred":[
         "A\u00efn T\u00e9mouchent"
     ],
+    "name:heb_x_preferred":[
+        "\u05e2\u05d9\u05df \u05d8\u05de\u05d0\u05d5\u05e9\u05e0\u05d8"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0575\u0576 \u0539\u0565\u0574\u0578\u0582\u0577\u0565\u0576\u0569"
+    ],
     "name:ita_x_preferred":[
         "\u02bfAyn Tem\u016bshent"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30a4\u30f3\u30fb\u30c6\u30a3\u30e0\u30b7\u30a7\u30f3\u30c8"
     ],
     "name:kab_x_preferred":[
         "\u0190in Timucent"
@@ -82,8 +106,14 @@
     "name:spa_x_preferred":[
         "A\u00efn T\u00e9mouchent"
     ],
+    "name:spa_x_variant":[
+        "A\u00edn Temushent"
+    ],
     "name:sqi_x_preferred":[
         "Ain Temouchent"
+    ],
+    "name:swa_x_preferred":[
+        "A\u00efn T\u00e9mouchent"
     ],
     "name:ukr_x_preferred":[
         "\u0410\u0439\u043d-\u0422\u0435\u043c\u0443\u0448\u0435\u043d\u0442"
@@ -93,6 +123,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0639\u06cc\u0646 \u062a\u0645\u0648\u0634\u0646\u062a"
+    ],
+    "name:uzb_x_preferred":[
+        "A\u00efn T\u00e9mouchent"
     ],
     "name:vie_x_preferred":[
         "Ain Temouchent"
@@ -134,7 +167,7 @@
         }
     ],
     "wof:id":890432335,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875553,
     "wof:name":"\u2019A\u00efn Temouchent",
     "wof:parent_id":85670683,
     "wof:placetype":"locality",

--- a/data/890/432/337/890432337.geojson
+++ b/data/890/432/337/890432337.geojson
@@ -25,10 +25,22 @@
     "name:ara_x_variant":[
         "\u0639\u064a\u0646 \u0637\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0637\u0627\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0637\u0627\u06cc\u0647"
     ],
+    "name:cat_x_preferred":[
+        "A\u00efn Taia"
+    ],
     "name:ceb_x_preferred":[
+        "A\u00efn Taya"
+    ],
+    "name:dan_x_preferred":[
+        "A\u00efn Taya"
+    ],
+    "name:deu_x_preferred":[
         "A\u00efn Taya"
     ],
     "name:eng_x_preferred":[
@@ -42,6 +54,9 @@
     ],
     "name:ita_x_preferred":[
         "A\u00efn Taya"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30a4\u30f3\u30fb\u30bf\u30e4"
     ],
     "name:kab_x_preferred":[
         "\u0190in \u1e6caya"
@@ -67,6 +82,12 @@
     "name:swe_x_preferred":[
         "A\u00efn Taya"
     ],
+    "name:tur_x_preferred":[
+        "Ayn Taya"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0410\u0439\u043d-\u0422\u0430\u0439\u0430"
+    ],
     "name:und_x_variant":[
         "A\u00efne Taya"
     ],
@@ -75,6 +96,9 @@
     ],
     "name:vie_x_preferred":[
         "Ain Taya"
+    ],
+    "name:zho_x_preferred":[
+        "\u827e\u56e0\u5854\u4e9a"
     ],
     "qs:name":"A\u00efn Taya",
     "qs:photos_9r":0,
@@ -107,7 +131,7 @@
         }
     ],
     "wof:id":890432337,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875552,
     "wof:name":"A\u00efn Taya",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/890/432/339/890432339.geojson
+++ b/data/890/432/339/890432339.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0633\u0645\u0627\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0633\u0645\u0627\u0631\u0647"
+    ],
     "name:ceb_x_preferred":[
         "A\u00efn Smara"
     ],
@@ -34,11 +37,17 @@
     "name:ita_x_preferred":[
         "A\u00efn Smara"
     ],
+    "name:kab_x_preferred":[
+        "\u0190in Smara"
+    ],
     "name:nan_x_preferred":[
         "A\u00efn Smara"
     ],
     "name:nld_x_preferred":[
         "A\u00efn Smara"
+    ],
+    "name:pol_x_preferred":[
+        "Ajn Smara"
     ],
     "name:por_x_preferred":[
         "A\u00efn Smara"
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":890432339,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875552,
     "wof:name":"A\u00efn Smara",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",

--- a/data/890/432/341/890432341.geojson
+++ b/data/890/432/341/890432341.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0643\u0631\u0634\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0643\u0631\u0634\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u06a9\u0631\u0634\u0647"
     ],
@@ -52,6 +55,9 @@
     "name:nld_x_preferred":[
         "A\u00efn Kercha"
     ],
+    "name:pol_x_preferred":[
+        "Ajn Karsza"
+    ],
     "name:por_x_preferred":[
         "A\u00efn Kercha"
     ],
@@ -72,6 +78,9 @@
     ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u51f1\u820d\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Kercha"
     ],
     "qs:name":"A\u00efn Kercha",
     "qs:photos_9r":0,
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":890432341,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875552,
     "wof:name":"A\u00efn Kercha",
     "wof:parent_id":85670871,
     "wof:placetype":"locality",

--- a/data/890/434/649/890434649.geojson
+++ b/data/890/434/649/890434649.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0631\u0646\u062f\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0631\u0646\u062f\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0641\u0631\u0646\u062f\u0647"
     ],
@@ -43,6 +46,9 @@
     "name:ita_x_preferred":[
         "Frenda"
     ],
+    "name:kab_x_preferred":[
+        "Frenda"
+    ],
     "name:msa_x_preferred":[
         "Frenda"
     ],
@@ -58,6 +64,9 @@
     "name:ron_x_preferred":[
         "Frenda"
     ],
+    "name:swa_x_preferred":[
+        "Frenda"
+    ],
     "name:swe_x_preferred":[
         "Frenda"
     ],
@@ -66,6 +75,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5f17\u502b\u9054"
+    ],
+    "name:zul_x_preferred":[
+        "Frenda"
     ],
     "qs:name":"Frenda",
     "qs:photos_9r":0,
@@ -98,7 +110,7 @@
         }
     ],
     "wof:id":890434649,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875551,
     "wof:name":"Frenda",
     "wof:parent_id":85670801,
     "wof:placetype":"locality",

--- a/data/890/434/651/890434651.geojson
+++ b/data/890/434/651/890434651.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0633\u0627\u0646\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0633\u0627\u0646\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0627\u0646\u06cc\u0647"
     ],
@@ -31,11 +34,17 @@
     "name:eng_x_preferred":[
         "Es S\u00e9nia"
     ],
+    "name:eng_x_variant":[
+        "Es Senia"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0627\u0646\u06cc\u0647"
     ],
     "name:fra_x_preferred":[
         "Es Senia"
+    ],
+    "name:fra_x_variant":[
+        "Es S\u00e9nia"
     ],
     "name:ita_x_preferred":[
         "Es Senia"
@@ -45,6 +54,9 @@
     ],
     "name:kab_x_preferred":[
         "Sanya"
+    ],
+    "name:kab_x_variant":[
+        "Ssanya"
     ],
     "name:msa_x_preferred":[
         "Es S\u00e9nia"
@@ -72,6 +84,9 @@
     ],
     "name:und_x_variant":[
         "La S\u00e9nia"
+    ],
+    "name:uzb_x_preferred":[
+        "Es S\u00e9nia"
     ],
     "name:vie_x_preferred":[
         "Es Senia"
@@ -110,7 +125,7 @@
         }
     ],
     "wof:id":890434651,
-    "wof:lastmodified":1566583515,
+    "wof:lastmodified":1690875550,
     "wof:name":"Es Senia",
     "wof:parent_id":85670689,
     "wof:placetype":"locality",

--- a/data/890/434/653/890434653.geojson
+++ b/data/890/434/653/890434653.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0625\u062f\u0631\u064a\u0633\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0627\u062f\u0631\u064a\u0633\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u0631\u06cc\u0633\u06cc\u0647"
     ],
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":890434653,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875551,
     "wof:name":"El Idrissia",
     "wof:parent_id":85670833,
     "wof:placetype":"locality",

--- a/data/890/434/655/890434655.geojson
+++ b/data/890/434/655/890434655.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u062d\u062c\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u062c\u0627\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u062d\u062c\u0627\u0631"
+    ],
+    "name:cat_x_preferred":[
+        "El Hadjar"
     ],
     "name:ceb_x_preferred":[
         "El Hadjar"
@@ -40,6 +46,9 @@
     "name:ita_x_preferred":[
         "El Hadjar"
     ],
+    "name:kab_x_preferred":[
+        "L\u1e25e\u01e7\u01e7ar"
+    ],
     "name:msa_x_preferred":[
         "El Hadjar"
     ],
@@ -48,6 +57,9 @@
     ],
     "name:nld_x_preferred":[
         "El Hadjar"
+    ],
+    "name:pol_x_preferred":[
+        "Al-Had\u017car"
     ],
     "name:por_x_preferred":[
         "El Hadjar"
@@ -60,6 +72,9 @@
     ],
     "name:swe_x_preferred":[
         "El Hadjar"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0415\u043b\u044c-\u0425\u0430\u0434\u0436\u0430\u0440"
     ],
     "name:und_x_variant":[
         "Duzerville"
@@ -98,7 +113,7 @@
         }
     ],
     "wof:id":890434655,
-    "wof:lastmodified":1566583516,
+    "wof:lastmodified":1690875551,
     "wof:name":"El Hadjar",
     "wof:parent_id":85670713,
     "wof:placetype":"locality",

--- a/data/890/434/657/890434657.geojson
+++ b/data/890/434/657/890434657.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0639\u0648\u064a\u0646\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u0648\u064a\u0646\u0627\u062a"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0648\u06cc\u0646\u0627\u062a"
     ],
@@ -70,11 +73,20 @@
     "name:und_x_variant":[
         "Clairefontaine"
     ],
+    "name:uzb_x_preferred":[
+        "Al-Aouinet"
+    ],
     "name:vie_x_preferred":[
         "El-Aouinnet"
     ],
     "name:zho_x_preferred":[
         "\u5967\u4f0a\u5948\u7279"
+    ],
+    "name:zho_x_variant":[
+        "\u6b27\u97e6\u7eb3\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "El Aouinet"
     ],
     "qs:name":"El Aouinet",
     "qs:photos_9r":0,
@@ -107,7 +119,7 @@
         }
     ],
     "wof:id":890434657,
-    "wof:lastmodified":1566583515,
+    "wof:lastmodified":1690875551,
     "wof:name":"El Aouinet",
     "wof:parent_id":85670879,
     "wof:placetype":"locality",

--- a/data/890/434/659/890434659.geojson
+++ b/data/890/434/659/890434659.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0639\u0627\u0645\u0631\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0639\u0627\u0645\u0631\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u0627\u0645\u0631\u06cc\u0647"
     ],
@@ -52,6 +55,9 @@
     "name:nld_x_preferred":[
         "El Amria"
     ],
+    "name:pol_x_preferred":[
+        "El Amria"
+    ],
     "name:por_x_preferred":[
         "El Amria"
     ],
@@ -66,6 +72,9 @@
     ],
     "name:und_x_variant":[
         "Lourmel"
+    ],
+    "name:uzb_x_preferred":[
+        "El Amria"
     ],
     "name:vie_x_preferred":[
         "El Amria"
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":890434659,
-    "wof:lastmodified":1566583515,
+    "wof:lastmodified":1690875551,
     "wof:name":"El Amria",
     "wof:parent_id":85670683,
     "wof:placetype":"locality",

--- a/data/890/435/437/890435437.geojson
+++ b/data/890/435/437/890435437.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0623\u0628\u064a\u0636 \u0633\u064a\u062f\u064a \u0627\u0644\u0634\u064a\u062e"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0627\u0628\u064a\u0636 \u0633\u064a\u062f\u0649 \u0627\u0644\u0634\u064a\u062e"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0628\u06cc\u0636 \u0633\u06cc\u062f\u06cc \u0634\u06cc\u062e"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "El Abiodh Sidi Cheikh"
+    ],
+    "name:kab_x_preferred":[
+        "Lebye\u1e0d Sidi Ccix"
     ],
     "name:msa_x_preferred":[
         "El Abiodh Sidi Cheikh"
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":890435437,
-    "wof:lastmodified":1566583518,
+    "wof:lastmodified":1690875555,
     "wof:name":"El Abiodh Sidi Cheikh",
     "wof:parent_id":85670741,
     "wof:placetype":"locality",

--- a/data/890/435/463/890435463.geojson
+++ b/data/890/435/463/890435463.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u062b\u0646\u064a\u0629 \u0627\u0644\u0623\u062d\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u062b\u0646\u064a\u0647 \u0627\u0644\u0627\u062d\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u062b\u0646\u06cc\u0647 \u0627\u062d\u062f"
     ],
@@ -39,6 +42,12 @@
     ],
     "name:ita_x_preferred":[
         "Theniet El Had"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c6\u30cb\u30a8\u30c8\u30fb\u30a8\u30eb\u30fb\u30cf\u30fc\u30c9"
+    ],
+    "name:kab_x_preferred":[
+        "Tneyyet L\u1e25edd"
     ],
     "name:msa_x_preferred":[
         "Th\u00e9niet El Had"
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":890435463,
-    "wof:lastmodified":1566583518,
+    "wof:lastmodified":1690875555,
     "wof:name":"Theniet el Had",
     "wof:parent_id":85670805,
     "wof:placetype":"locality",

--- a/data/890/435/465/890435465.geojson
+++ b/data/890/435/465/890435465.geojson
@@ -25,6 +25,9 @@
     "name:arq_x_preferred":[
         "\u0627\u0644\u062a\u0644\u0627\u063a\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062a\u0644\u0627\u063a\u0645\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0644\u0627\u063a\u0645\u0647"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30c6\u30ec\u30eb\u30b0\u30de"
+    ],
+    "name:kab_x_preferred":[
+        "Tla\u0263ma"
     ],
     "name:msa_x_preferred":[
         "Telerghma"
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":890435465,
-    "wof:lastmodified":1566583518,
+    "wof:lastmodified":1690875555,
     "wof:name":"Telerghma",
     "wof:parent_id":85670867,
     "wof:placetype":"locality",

--- a/data/890/435/467/890435467.geojson
+++ b/data/890/435/467/890435467.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0631\u0645\u0634\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0631\u0645\u0634\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Remchi"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:kab_x_preferred":[
         "Remci"
+    ],
+    "name:kab_x_variant":[
+        "Rremci"
     ],
     "name:msa_x_preferred":[
         "Remchi"
@@ -64,7 +70,13 @@
     "name:und_x_variant":[
         "Montagnac"
     ],
+    "name:uzb_x_preferred":[
+        "Remchi"
+    ],
     "name:vie_x_preferred":[
+        "Remchi"
+    ],
+    "name:zul_x_preferred":[
         "Remchi"
     ],
     "qs:name":"Remchi",
@@ -98,7 +110,7 @@
         }
     ],
     "wof:id":890435467,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875557,
     "wof:name":"Remchi",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/890/435/469/890435469.geojson
+++ b/data/890/435/469/890435469.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0644\u0627\u062f \u0645\u0648\u0633\u0649"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0644\u0627\u062f \u0645\u0648\u0633\u0649"
+    ],
+    "name:aze_x_preferred":[
+        "Ulad-Musa"
+    ],
     "name:ceb_x_preferred":[
         "Ouled Moussa"
     ],
@@ -34,8 +40,14 @@
     "name:fra_x_preferred":[
         "Ouled Moussa"
     ],
+    "name:hye_x_preferred":[
+        "\u0548\u0582\u056c\u0561\u0564 \u0544\u0578\u0582\u057d\u0561"
+    ],
     "name:ita_x_preferred":[
         "Ouled Moussa"
+    ],
+    "name:kab_x_preferred":[
+        "Wlad Musa"
     ],
     "name:msa_x_preferred":[
         "Ouled Moussa"
@@ -98,7 +110,7 @@
         }
     ],
     "wof:id":890435469,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875557,
     "wof:name":"Ouled Moussa",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/890/435/471/890435471.geojson
+++ b/data/890/435/471/890435471.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0644\u0627\u062f \u0645\u064a\u0645\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0644\u0627\u062f \u0645\u064a\u0645\u0648\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0648\u0644\u0627\u062f \u0645\u06cc\u0645\u0648\u0646"
     ],
@@ -73,7 +76,13 @@
     "name:und_x_variant":[
         "Lamorici\u00e8re"
     ],
+    "name:uzb_x_preferred":[
+        "Ouled Mimun"
+    ],
     "name:vie_x_preferred":[
+        "Ouled Mimoun"
+    ],
+    "name:zul_x_preferred":[
         "Ouled Mimoun"
     ],
     "qs:name":"Ouled Mimoun",
@@ -107,7 +116,7 @@
         }
     ],
     "wof:id":890435471,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1690875554,
     "wof:name":"Ouled Mimoun",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/890/435/473/890435473.geojson
+++ b/data/890/435/473/890435473.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0627\u062f\u064a \u0627\u0644\u0623\u0628\u0637\u0627\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0648\u0627\u062f\u0649 \u0627\u0644\u0627\u0628\u0637\u0627\u0644"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0627\u062f\u06cc \u0627\u0628\u0637\u0627\u0644"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:kab_x_preferred":[
         "Asif Lab\u1e6dal"
+    ],
+    "name:kab_x_variant":[
+        "Wad Leb\u1e6dal"
     ],
     "name:msa_x_preferred":[
         "Oued El Abtal"
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":890435473,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875557,
     "wof:name":"Oued el Abtal",
     "wof:parent_id":85670785,
     "wof:placetype":"locality",

--- a/data/890/435/477/890435477.geojson
+++ b/data/890/435/477/890435477.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a \u062f\u0648\u0627\u0644\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u0649 \u062f\u0648\u0627\u0644\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u06cc \u062f\u0648\u0627\u0644\u0647"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:kab_x_preferred":[
         "Ta \u0263iwant n At Dwala"
+    ],
+    "name:kab_x_variant":[
+        "At Dwala"
     ],
     "name:msa_x_preferred":[
         "Beni Douala"
@@ -67,11 +73,17 @@
     "name:und_x_variant":[
         "Beni Doula"
     ],
+    "name:uzb_x_preferred":[
+        "Beni Duala"
+    ],
     "name:vie_x_preferred":[
         "Beni-Douala"
     ],
     "name:zho_x_preferred":[
         "\u8c9d\u5c3c\u675c\u74e6\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Beni Douala"
     ],
     "qs:name":"Beni Douala",
     "qs:photos_9r":0,
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":890435477,
-    "wof:lastmodified":1566583518,
+    "wof:lastmodified":1690875554,
     "wof:name":"Beni Douala",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/890/435/747/890435747.geojson
+++ b/data/890/435/747/890435747.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0632\u0627\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0632\u0627\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0648\u0632\u0627\u06cc\u0647"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "Mouzaia"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30e0\u30b6\u30a4\u30a2"
     ],
     "name:kab_x_preferred":[
         "Muzaya"
@@ -73,6 +79,9 @@
     "name:vie_x_preferred":[
         "Mouzaia"
     ],
+    "name:zul_x_preferred":[
+        "Mouza\u00efa"
+    ],
     "qs:name":"Mouza\u00efa",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":890435747,
-    "wof:lastmodified":1566583518,
+    "wof:lastmodified":1690875555,
     "wof:name":"Mouza\u00efa",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/890/435/749/890435749.geojson
+++ b/data/890/435/749/890435749.geojson
@@ -22,6 +22,24 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0644\u0629"
     ],
+    "name:arq_x_preferred":[
+        "\u0645\u064a\u0644\u0627/\u0645\u064a\u0644\u0627\u06a5"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0644\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Mila"
+    ],
+    "name:aze_x_preferred":[
+        "Mila"
+    ],
+    "name:bel_x_preferred":[
+        "\u041c\u0456\u043b\u0430"
+    ],
+    "name:cat_x_preferred":[
+        "Mila"
+    ],
     "name:ceb_x_preferred":[
         "Mila"
     ],
@@ -32,6 +50,9 @@
         "\u039c\u03af\u03bb\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Mila"
+    ],
+    "name:eus_x_preferred":[
         "Mila"
     ],
     "name:fra_x_preferred":[
@@ -46,11 +67,17 @@
     "name:ita_x_preferred":[
         "diocesi di Milevi"
     ],
+    "name:ita_x_variant":[
+        "Mila"
+    ],
     "name:kab_x_preferred":[
         "Mila"
     ],
     "name:kor_x_preferred":[
         "\ubc00\ub77c"
+    ],
+    "name:lat_x_preferred":[
+        "Milevum"
     ],
     "name:msa_x_preferred":[
         "Mila"
@@ -60,6 +87,9 @@
     ],
     "name:nld_x_preferred":[
         "Mila"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0645\u06cc\u0644\u06c1"
     ],
     "name:pol_x_preferred":[
         "Mila"
@@ -76,6 +106,9 @@
     "name:spa_x_preferred":[
         "Mila"
     ],
+    "name:swa_x_preferred":[
+        "Mila"
+    ],
     "name:swe_x_preferred":[
         "Mila"
     ],
@@ -90,6 +123,9 @@
     ],
     "name:war_x_preferred":[
         "Mila"
+    ],
+    "name:zho_x_preferred":[
+        "\u7c73\u62c9"
     ],
     "qs:name":"Mila",
     "qs:photos_9r":0,
@@ -122,7 +158,7 @@
         }
     ],
     "wof:id":890435749,
-    "wof:lastmodified":1636501723,
+    "wof:lastmodified":1690875556,
     "wof:name":"Mila",
     "wof:parent_id":85670867,
     "wof:placetype":"locality",

--- a/data/890/435/751/890435751.geojson
+++ b/data/890/435/751/890435751.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0645\u062a\u0644\u064a\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u062a\u0644\u064a\u0644\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u062a\u0644\u06cc\u0644\u06cc"
     ],
     "name:ceb_x_preferred":[
         "Metlili Chaamba"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b5\u03c4\u03bb\u03b9\u03bb\u03af"
     ],
     "name:eng_x_preferred":[
         "Metlili"
@@ -42,6 +48,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30e1\u30c8\u30ea\u30ea"
+    ],
+    "name:kab_x_preferred":[
+        "Metlili"
     ],
     "name:msa_x_preferred":[
         "Metlili"
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":890435751,
-    "wof:lastmodified":1566583518,
+    "wof:lastmodified":1690875556,
     "wof:name":"Metlili Chaamba",
     "wof:parent_id":85670749,
     "wof:placetype":"locality",

--- a/data/890/435/753/890435753.geojson
+++ b/data/890/435/753/890435753.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0645\u0633\u0643\u064a\u0627\u0646\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0633\u0643\u064a\u0627\u0646\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0633\u06a9\u06cc\u0627\u0646\u0647"
+    ],
+    "name:cat_x_preferred":[
+        "Meskiana"
     ],
     "name:ceb_x_preferred":[
         "Meskiana"
@@ -64,11 +70,17 @@
     "name:und_x_variant":[
         "La Meskiana"
     ],
+    "name:uzb_x_preferred":[
+        "Meskiana"
+    ],
     "name:vie_x_preferred":[
         "Meskiana"
     ],
     "name:zho_x_preferred":[
         "\u9081\u65af\u57fa\u4e9e\u7d0d"
+    ],
+    "name:zul_x_preferred":[
+        "Meskiana"
     ],
     "qs:name":"Meskiana",
     "qs:photos_9r":0,
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":890435753,
-    "wof:lastmodified":1566583517,
+    "wof:lastmodified":1690875554,
     "wof:name":"Meskiana",
     "wof:parent_id":85670871,
     "wof:placetype":"locality",

--- a/data/890/435/757/890435757.geojson
+++ b/data/890/435/757/890435757.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0647\u062f\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0647\u062f\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0647\u062f\u06cc\u0647"
     ],
@@ -76,6 +79,9 @@
     "name:vie_x_preferred":[
         "Mahdia"
     ],
+    "name:zul_x_preferred":[
+        "Mahdia"
+    ],
     "qs:name":"Mehdia",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -109,7 +115,7 @@
         }
     ],
     "wof:id":890435757,
-    "wof:lastmodified":1566583518,
+    "wof:lastmodified":1690875556,
     "wof:name":"Mehdia",
     "wof:parent_id":85670801,
     "wof:placetype":"locality",

--- a/data/890/435/759/890435759.geojson
+++ b/data/890/435/759/890435759.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0645\u0642\u0627\u0631\u064a\u0646\u060c\u0648\u0631\u0642\u0644\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0642\u0627\u0631\u064a\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0642\u0627\u0631\u06cc\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "M\u0259qarin"
     ],
     "name:ceb_x_preferred":[
         "Megarine"
@@ -39,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Megarine"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30e1\u30ac\u30ea\u30fc\u30cc"
     ],
     "name:msa_x_preferred":[
         "Megarine"
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":890435759,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875556,
     "wof:name":"Megarine",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",

--- a/data/890/435/761/890435761.geojson
+++ b/data/890/435/761/890435761.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0645\u0641\u062a\u0627\u062d"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0641\u062a\u0627\u062d"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0641\u062a\u0627\u062d"
+    ],
+    "name:cat_x_preferred":[
+        "Meftah"
     ],
     "name:ceb_x_preferred":[
         "Meftah"
@@ -76,6 +82,9 @@
     "name:vie_x_preferred":[
         "Meftah"
     ],
+    "name:zul_x_preferred":[
+        "Meftah"
+    ],
     "qs:name":"Meftah",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -107,7 +116,7 @@
         }
     ],
     "wof:id":890435761,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875556,
     "wof:name":"Meftah",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/890/435/973/890435973.geojson
+++ b/data/890/435/973/890435973.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u062c\u062f\u064a\u0648\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u062f\u064a\u0648\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u062f\u06cc\u0648\u06cc\u0647"
+    ],
+    "name:cat_x_preferred":[
+        "Djidioua"
     ],
     "name:ceb_x_preferred":[
         "Djidiouia"
@@ -42,6 +48,9 @@
     ],
     "name:kab_x_preferred":[
         "Jidiweyya"
+    ],
+    "name:kab_x_variant":[
+        "Jdiwya"
     ],
     "name:msa_x_preferred":[
         "Djidioua"
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":890435973,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875557,
     "wof:name":"Djidiouia",
     "wof:parent_id":85670791,
     "wof:placetype":"locality",

--- a/data/890/435/975/890435975.geojson
+++ b/data/890/435/975/890435975.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0622\u063a\u0631\u0627\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u063a\u0631\u0627\u0645"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u063a\u0631\u0627\u0645"
     ],
@@ -52,6 +55,9 @@
     "name:nld_x_preferred":[
         "Ighram"
     ],
+    "name:pol_x_preferred":[
+        "Ighram"
+    ],
     "name:por_x_preferred":[
         "Ighram"
     ],
@@ -72,6 +78,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4f0a\u683c\u62c9\u59c6"
+    ],
+    "name:zul_x_preferred":[
+        "Ighram"
     ],
     "qs:name":"Ighram",
     "qs:photos_9r":0,
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":890435975,
-    "wof:lastmodified":1566583519,
+    "wof:lastmodified":1690875557,
     "wof:name":"Ighram",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/890/436/701/890436701.geojson
+++ b/data/890/436/701/890436701.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0633\u062f\u0631\u0627\u062a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u062f\u0631\u0627\u062a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u062f\u0631\u0627\u062a\u0647"
     ],
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":890436701,
-    "wof:lastmodified":1566583510,
+    "wof:lastmodified":1690875545,
     "wof:name":"Sedrata",
     "wof:parent_id":85670875,
     "wof:placetype":"locality",

--- a/data/890/436/705/890436705.geojson
+++ b/data/890/436/705/890436705.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0642\u0627\u062f\u064a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0642\u0627\u062f\u064a\u0631"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u0642\u0627\u062f\u06cc\u0631"
     ],
@@ -76,6 +79,9 @@
     "name:zho_x_preferred":[
         "\u5e03\u5361\u8fea\u723e"
     ],
+    "name:zul_x_preferred":[
+        "Boukadir"
+    ],
     "qs:name":"Boukadir",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":890436705,
-    "wof:lastmodified":1566583510,
+    "wof:lastmodified":1690875545,
     "wof:name":"Boukadir",
     "wof:parent_id":85670781,
     "wof:placetype":"locality",

--- a/data/890/436/777/890436777.geojson
+++ b/data/890/436/777/890436777.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u062a\u0648\u062a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u062a\u0648\u062a\u0647"
+    ],
     "name:ceb_x_preferred":[
         "A\u00efn Touta"
     ],
@@ -49,10 +52,16 @@
     "name:nld_x_preferred":[
         "A\u00efn Touta"
     ],
+    "name:pol_x_preferred":[
+        "Ajn at-Tuta"
+    ],
     "name:por_x_preferred":[
         "A\u00efn Touta"
     ],
     "name:ron_x_preferred":[
+        "A\u00efn Touta"
+    ],
+    "name:swa_x_preferred":[
         "A\u00efn Touta"
     ],
     "name:swe_x_preferred":[
@@ -63,6 +72,9 @@
     ],
     "name:vie_x_preferred":[
         "Ain Touta"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Touta"
     ],
     "qs:name":"A\u00efn Touta",
     "qs:photos_9r":0,
@@ -95,7 +107,7 @@
         }
     ],
     "wof:id":890436777,
-    "wof:lastmodified":1566583510,
+    "wof:lastmodified":1690875545,
     "wof:name":"A\u00efn Touta",
     "wof:parent_id":85670851,
     "wof:placetype":"locality",

--- a/data/890/436/901/890436901.geojson
+++ b/data/890/436/901/890436901.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0645\u064a\u0645\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0645\u064a\u0645\u0648\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0645\u06cc\u0645\u0648\u0646"
     ],
@@ -40,11 +43,17 @@
     "name:deu_x_preferred":[
         "Timimoun"
     ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03b9\u03bc\u03b9\u03bc\u03bf\u03cd\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Timimoun"
     ],
     "name:fas_x_preferred":[
         "\u062a\u06cc\u0645\u06cc\u0645\u0648\u0646"
+    ],
+    "name:fin_x_preferred":[
+        "Timimoun"
     ],
     "name:fra_x_preferred":[
         "Timimoun"
@@ -57,6 +66,9 @@
     ],
     "name:hun_x_preferred":[
         "Timimoun"
+    ],
+    "name:hye_x_preferred":[
+        "\u0539\u056b\u0574\u056b\u0574\u0578\u0582\u0576"
     ],
     "name:ind_x_preferred":[
         "Timimoun"
@@ -120,6 +132,9 @@
     ],
     "name:zho_x_preferred":[
         "\u63d0\u7c73\u8499"
+    ],
+    "name:zul_x_preferred":[
+        "Timimoun"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -253,7 +268,7 @@
         }
     ],
     "wof:id":890436901,
-    "wof:lastmodified":1636501722,
+    "wof:lastmodified":1690875545,
     "wof:name":"Timimoun",
     "wof:parent_id":85670677,
     "wof:placetype":"locality",

--- a/data/890/437/127/890437127.geojson
+++ b/data/890/437/127/890437127.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0644\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0644\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0648\u0644\u0641"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fulef"
     ],
     "name:bar_x_preferred":[
         "Aoulef"
@@ -40,6 +46,9 @@
     "name:fas_x_preferred":[
         "\u0627\u0648\u0644\u0641"
     ],
+    "name:fin_x_preferred":[
+        "Aoulef"
+    ],
     "name:fra_x_preferred":[
         "Aoulef"
     ],
@@ -49,6 +58,9 @@
     "name:kab_x_preferred":[
         "Awlaf"
     ],
+    "name:kab_x_variant":[
+        "Awlef"
+    ],
     "name:msa_x_preferred":[
         "Aoulef"
     ],
@@ -56,6 +68,9 @@
         "Aoulef"
     ],
     "name:nld_x_preferred":[
+        "Aoulef"
+    ],
+    "name:pol_x_preferred":[
         "Aoulef"
     ],
     "name:por_x_preferred":[
@@ -84,6 +99,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5967\u840a\u592b"
+    ],
+    "name:zul_x_preferred":[
+        "Aoulef"
     ],
     "qs:name":"Aoulef",
     "qs:photos_9r":0,
@@ -116,7 +134,7 @@
         }
     ],
     "wof:id":890437127,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875543,
     "wof:name":"Aoulef",
     "wof:parent_id":85670677,
     "wof:placetype":"locality",

--- a/data/890/437/135/890437135.geojson
+++ b/data/890/437/135/890437135.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0632\u0645\u0648\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0632\u0645\u0648\u0631\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0632\u0645\u0648\u0631\u0647"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "Zemmora"
+    ],
+    "name:kab_x_preferred":[
+        "Zemmura"
     ],
     "name:msa_x_preferred":[
         "Zemmoura"
@@ -96,7 +102,7 @@
         }
     ],
     "wof:id":890437135,
-    "wof:lastmodified":1566583508,
+    "wof:lastmodified":1690875542,
     "wof:name":"Zemoura",
     "wof:parent_id":85670791,
     "wof:placetype":"locality",

--- a/data/890/437/137/890437137.geojson
+++ b/data/890/437/137/890437137.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0645\u064a\u0632\u0627\u0631\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u0645\u064a\u0632\u0627\u0631\u062a"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u06cc\u0645\u06cc\u0632\u0627\u0631\u062a"
     ],
@@ -64,11 +67,17 @@
     "name:swe_x_preferred":[
         "Timizart"
     ],
+    "name:uzb_x_preferred":[
+        "Timizart"
+    ],
     "name:vie_x_preferred":[
         "Timizart"
     ],
     "name:zho_x_preferred":[
         "\u63d0\u7c73\u624e\u723e\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Timizart"
     ],
     "qs:name":"Timizart",
     "qs:photos_9r":0,
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":890437137,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875544,
     "wof:name":"Timizart",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/890/437/139/890437139.geojson
+++ b/data/890/437/139/890437139.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0643\u0648\u062f\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0643\u0648\u062f\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u06a9\u0648\u062f\u0647"
     ],
@@ -67,11 +70,17 @@
     "name:und_x_variant":[
         "Macouda"
     ],
+    "name:uzb_x_preferred":[
+        "Makouda"
+    ],
     "name:vie_x_preferred":[
         "Makouda"
     ],
     "name:zho_x_preferred":[
         "\u99ac\u5eab\u9054"
+    ],
+    "name:zul_x_preferred":[
+        "Makouda"
     ],
     "qs:name":"Makouda",
     "qs:photos_9r":0,
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":890437139,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875544,
     "wof:name":"Makouda",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/890/437/143/890437143.geojson
+++ b/data/890/437/143/890437143.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0637\u064a\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0637\u064a\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0637\u06cc\u0647"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "Chettia"
+    ],
+    "name:kab_x_preferred":[
+        "Ce\u1e6d\u1e6deyya"
     ],
     "name:lit_x_preferred":[
         "\u0160etija"
@@ -58,11 +64,20 @@
     "name:ron_x_preferred":[
         "Chettia"
     ],
+    "name:rus_x_preferred":[
+        "\u0428\u0435\u0442\u0442\u0438\u0430"
+    ],
     "name:spa_x_preferred":[
+        "Chettia"
+    ],
+    "name:swa_x_preferred":[
         "Chettia"
     ],
     "name:swe_x_preferred":[
         "Ech Chettia"
+    ],
+    "name:tur_x_preferred":[
+        "Chettia"
     ],
     "name:und_x_variant":[
         "Ech Ch\u00e9tia"
@@ -71,6 +86,9 @@
         "\u0634\u0637\u06cc\u06c1"
     ],
     "name:vie_x_preferred":[
+        "Chettia"
+    ],
+    "name:zul_x_preferred":[
         "Chettia"
     ],
     "qs:name":"Ech Chettia",
@@ -102,7 +120,7 @@
         }
     ],
     "wof:id":890437143,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875543,
     "wof:name":"Ech Chettia",
     "wof:parent_id":85670781,
     "wof:placetype":"locality",

--- a/data/890/437/145/890437145.geojson
+++ b/data/890/437/145/890437145.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0630\u0631\u0639\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0630\u0631\u0639\u0627\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "Dre\u00f6n"
+    ],
     "name:bul_x_preferred":[
         "\u0414\u0440\u0435\u0430\u043d"
     ],
@@ -37,6 +43,9 @@
     "name:deu_x_preferred":[
         "Dr\u00e9an"
     ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03c1\u03b5\u03ac\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Dr\u00e9an"
     ],
@@ -50,6 +59,9 @@
         "Dr\u00e9an"
     ],
     "name:gla_x_preferred":[
+        "Dr\u00e9an"
+    ],
+    "name:gle_x_preferred":[
         "Dr\u00e9an"
     ],
     "name:heb_x_preferred":[
@@ -76,6 +88,9 @@
     "name:kat_x_preferred":[
         "\u10d3\u10e0\u10d4\u10d0\u10dc\u10d8"
     ],
+    "name:lit_x_preferred":[
+        "Dreanas"
+    ],
     "name:ltz_x_preferred":[
         "Dr\u00e9an"
     ],
@@ -86,6 +101,9 @@
         "Dr\u00e9an"
     ],
     "name:nld_x_preferred":[
+        "Dr\u00e9an"
+    ],
+    "name:pol_x_preferred":[
         "Dr\u00e9an"
     ],
     "name:por_x_preferred":[
@@ -146,7 +164,7 @@
         }
     ],
     "wof:id":890437145,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875543,
     "wof:name":"Drean",
     "wof:parent_id":85670719,
     "wof:placetype":"locality",

--- a/data/890/437/147/890437147.geojson
+++ b/data/890/437/147/890437147.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0634\u0644\u063a\u0648\u0645 \u0627\u0644\u0639\u064a\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0644\u063a\u0648\u0645 \u0627\u0644\u0639\u064a\u062f"
+    ],
+    "name:ast_x_preferred":[
+        "Chelghoum La\u00efd"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0644\u063a\u0648\u0645 \u0639\u06cc\u062f"
+    ],
+    "name:ceb_x_preferred":[
+        "Chelghoum el A\u00efd"
     ],
     "name:eng_x_preferred":[
         "Chelghoum La\u00efd"
@@ -36,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Chelghoum La\u00efd"
+    ],
+    "name:kab_x_preferred":[
+        "Cel\u0263um L\u025bid"
     ],
     "name:msa_x_preferred":[
         "Chelghoum La\u00efd"
@@ -54,6 +66,9 @@
     ],
     "name:spa_x_preferred":[
         "Chelghoum La\u00efd"
+    ],
+    "name:swa_x_preferred":[
+        "Chelghoum Laid"
     ],
     "name:swe_x_preferred":[
         "Chelghoum La\u00efd"
@@ -93,7 +108,7 @@
         }
     ],
     "wof:id":890437147,
-    "wof:lastmodified":1566583510,
+    "wof:lastmodified":1690875545,
     "wof:name":"Chelghoum el A\u00efd",
     "wof:parent_id":85670867,
     "wof:placetype":"locality",

--- a/data/890/437/151/890437151.geojson
+++ b/data/890/437/151/890437151.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0634\u0627\u0631\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0634\u0627\u0631\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u0634\u0627\u0631\u0641"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "Charef"
+    ],
+    "name:kab_x_preferred":[
+        "Ccaref"
     ],
     "name:msa_x_preferred":[
         "Charef"
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":890437151,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875543,
     "wof:name":"Charef",
     "wof:parent_id":85670833,
     "wof:placetype":"locality",

--- a/data/890/437/153/890437153.geojson
+++ b/data/890/437/153/890437153.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0634\u0639\u0628\u0629 \u0627\u0644\u0639\u0627\u0645\u0631"
     ],
+    "name:aze_x_preferred":[
+        "\u015e\u0259\u0259ba \u0259l-\u018fmr"
+    ],
     "name:ceb_x_preferred":[
         "Chabet el Ameur"
     ],
     "name:eng_x_preferred":[
         "Chabet el Ameur"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0639\u0628\u0647 \u0627\u0644\u0639\u0627\u0645\u0631"
     ],
     "name:fra_x_preferred":[
         "Chabet el Ameur"
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":890437153,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875543,
     "wof:name":"Chabet el Ameur",
     "wof:parent_id":85670765,
     "wof:placetype":"locality",

--- a/data/890/437/155/890437155.geojson
+++ b/data/890/437/155/890437155.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0648 \u0625\u0633\u0645\u0627\u0639\u064a\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648 \u0627\u0633\u0645\u0627\u0639\u064a\u0644"
+    ],
     "name:ceb_x_preferred":[
         "Bou Isma\u00efl"
     ],
@@ -30,6 +33,9 @@
     ],
     "name:fra_x_preferred":[
         "Bou Isma\u00efl"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d5 \u05d0\u05d9\u05e1\u05de\u05e2\u05d9\u05dc"
     ],
     "name:ita_x_preferred":[
         "Bou Isma\u00efl"
@@ -70,6 +76,9 @@
     "name:vie_x_preferred":[
         "Bou Ismail"
     ],
+    "name:zho_x_preferred":[
+        "\u5e03\u4f0a\u65af\u6885\u5c14"
+    ],
     "qs:name":"Bou Isma\u00efl",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":890437155,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875544,
     "wof:name":"Bou Isma\u00efl",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/437/157/890437157.geojson
+++ b/data/890/437/157/890437157.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_variant":[
         "\u0628\u0648\u064a\u0646\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u064a\u0646\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u06cc\u0646\u0627\u0646"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:eng_x_preferred":[
         "Bou\u00efnian"
+    ],
+    "name:eng_x_variant":[
+        "Bouinan"
     ],
     "name:fas_x_preferred":[
         "\u0628\u0648\u06cc\u0646\u0627\u0646"
@@ -76,6 +82,9 @@
     "name:vie_x_preferred":[
         "Bouinan"
     ],
+    "name:zul_x_preferred":[
+        "Bouinan"
+    ],
     "qs:name":"Bouinan",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -107,7 +116,7 @@
         }
     ],
     "wof:id":890437157,
-    "wof:lastmodified":1566583508,
+    "wof:lastmodified":1690875542,
     "wof:name":"Bouinan",
     "wof:parent_id":85670819,
     "wof:placetype":"locality",

--- a/data/890/437/159/890437159.geojson
+++ b/data/890/437/159/890437159.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0628\u0646 \u0633\u0643\u0631\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646 \u0633\u0643\u0631\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646 \u0633\u06a9\u0631\u0627\u0646"
     ],
     "name:ceb_x_preferred":[
         "Bensekrane"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03bd\u03c3\u03b5\u03ba\u03c1\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Bensekrane"
@@ -73,6 +79,9 @@
     "name:vie_x_preferred":[
         "Bensekrane"
     ],
+    "name:zul_x_preferred":[
+        "Bensekrane"
+    ],
     "qs:name":"Bensekrane",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":890437159,
-    "wof:lastmodified":1566583508,
+    "wof:lastmodified":1690875542,
     "wof:name":"Bensekrane",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/890/437/161/890437161.geojson
+++ b/data/890/437/161/890437161.geojson
@@ -22,14 +22,23 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u062d\u0645\u0627\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u062d\u0645\u0627\u0645"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0627\u0644\u062d\u0645\u0627\u0645"
     ],
     "name:cat_x_preferred":[
         "Ain El Hammam"
     ],
+    "name:ceb_x_preferred":[
+        "'A\u00efn el Hammam"
+    ],
     "name:deu_x_preferred":[
         "A\u00efn El Hammam"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u0390\u03bd \u0395\u03bb \u03a7\u03b1\u03bc\u03ac\u03bc"
     ],
     "name:eng_x_preferred":[
         "A\u00efn El Hammam"
@@ -73,14 +82,23 @@
     "name:swe_x_preferred":[
         "A\u00efn El Hammam"
     ],
+    "name:ukr_x_preferred":[
+        "\u0410\u0457\u043d \u0415\u043b\u044c \u0425\u0430\u043c\u043c\u0430\u043c"
+    ],
     "name:und_x_variant":[
         "Michelet"
+    ],
+    "name:urd_x_preferred":[
+        "\u0639\u06cc\u0646 \u0627\u0644\u062d\u0645\u0627\u0645"
     ],
     "name:vie_x_preferred":[
         "Ain-El-Hammam"
     ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u54c8\u99ac\u59c6"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn El Hammam"
     ],
     "qs:name":"\u2019A\u00efn el Hammam",
     "qs:photos_9r":0,
@@ -113,7 +131,7 @@
         }
     ],
     "wof:id":890437161,
-    "wof:lastmodified":1566583508,
+    "wof:lastmodified":1690875542,
     "wof:name":"\u2019A\u00efn el Hammam",
     "wof:parent_id":85670767,
     "wof:placetype":"locality",

--- a/data/890/437/163/890437163.geojson
+++ b/data/890/437/163/890437163.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0627\u0644\u062d\u062c\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0627\u0644\u062d\u062c\u0644"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u062d\u062c\u0644"
     ],
@@ -43,6 +46,9 @@
     "name:ita_x_preferred":[
         "A\u00efn El Hadjel"
     ],
+    "name:kab_x_preferred":[
+        "\u0190in Le\u1e25\u01e7el"
+    ],
     "name:msa_x_preferred":[
         "A\u00efn El Hadjel"
     ],
@@ -54,6 +60,9 @@
     ],
     "name:nor_x_preferred":[
         "Ain el Hadjel"
+    ],
+    "name:pol_x_preferred":[
+        "Ajn al-Had\u017cal"
     ],
     "name:por_x_preferred":[
         "A\u00efn El Hadjel"
@@ -69,6 +78,9 @@
     ],
     "name:und_x_variant":[
         "Selamate"
+    ],
+    "name:uzb_x_preferred":[
+        "Ain El Hadjel"
     ],
     "name:vie_x_preferred":[
         "Ain El Hadjel"
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":890437163,
-    "wof:lastmodified":1566583509,
+    "wof:lastmodified":1690875544,
     "wof:name":"\u2018A\u00efn el Hadjel",
     "wof:parent_id":85670841,
     "wof:placetype":"locality",

--- a/data/890/439/959/890439959.geojson
+++ b/data/890/439/959/890439959.geojson
@@ -31,11 +31,17 @@
     "name:arz_x_preferred":[
         "\u0642\u0633\u0646\u0637\u064a\u0646\u0647"
     ],
+    "name:ast_x_preferred":[
+        "Constantine"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0633\u0646\u0637\u06cc\u0646\u0647"
     ],
     "name:aze_x_preferred":[
         "Konstantin"
+    ],
+    "name:aze_x_variant":[
+        "Q\u00fcs\u0259ntin\u0259"
     ],
     "name:bel_x_preferred":[
         "\u041a\u0430\u043d\u0441\u0442\u0430\u043d\u0446\u0456\u043d\u0430"
@@ -54,6 +60,9 @@
     ],
     "name:ces_x_preferred":[
         "Constantine"
+    ],
+    "name:cos_x_preferred":[
+        "Costantina"
     ],
     "name:cym_x_preferred":[
         "Constantine"
@@ -91,6 +100,15 @@
     "name:fra_x_preferred":[
         "Constantine"
     ],
+    "name:frr_x_preferred":[
+        "Constantine"
+    ],
+    "name:fry_x_preferred":[
+        "Konstantine"
+    ],
+    "name:gle_x_preferred":[
+        "Constantine"
+    ],
     "name:glg_x_preferred":[
         "Constantina"
     ],
@@ -114,6 +132,9 @@
     ],
     "name:hye_x_preferred":[
         "\u053f\u0578\u0576\u057d\u057f\u0561\u0576\u057f\u056b\u0576\u0561"
+    ],
+    "name:ido_x_preferred":[
+        "Constantine"
     ],
     "name:ind_x_preferred":[
         "Constantine"
@@ -145,6 +166,9 @@
     "name:lat_x_preferred":[
         "Cirta"
     ],
+    "name:lat_x_variant":[
+        "Constantina Algerii"
+    ],
     "name:lav_x_preferred":[
         "Konstantina"
     ],
@@ -174,6 +198,9 @@
     ],
     "name:oci_x_preferred":[
         "Constantina"
+    ],
+    "name:oss_x_preferred":[
+        "\u041a\u043e\u043d\u0441\u0442\u0430\u043d\u0442\u0438\u043d\u00e6"
     ],
     "name:pnb_x_preferred":[
         "\u0642\u0633\u0646\u0637\u06cc\u0646\u06c1"
@@ -208,8 +235,14 @@
     "name:srp_x_preferred":[
         "\u041a\u043e\u043d\u0441\u0442\u0430\u043d\u0442\u0438\u043d"
     ],
+    "name:swa_x_preferred":[
+        "Constantine"
+    ],
     "name:swe_x_preferred":[
         "Constantine"
+    ],
+    "name:szl_x_preferred":[
+        "K\u016fnstantyna"
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbe\u0ba9\u0bcd\u0bb8\u0bcd\u0b9f\u0ba9\u0bcd\u0b9f\u0bc8\u0ba9\u0bcd"
@@ -223,6 +256,9 @@
     "name:tur_x_preferred":[
         "Konstantin"
     ],
+    "name:uig_x_preferred":[
+        "\u0642\u06c7\u0633\u06d5\u0646\u062a\u0649\u0646\u06d5"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u043d\u0441\u0442\u0430\u043d\u0442\u0456\u043d\u0430"
     ],
@@ -232,6 +268,12 @@
     "name:uzb_x_preferred":[
         "Konstantina"
     ],
+    "name:uzb_x_variant":[
+        "Qusantina"
+    ],
+    "name:vec_x_preferred":[
+        "Costantina"
+    ],
     "name:vie_x_preferred":[
         "Constantine"
     ],
@@ -239,6 +281,9 @@
         "Constantine"
     ],
     "name:wuu_x_preferred":[
+        "\u541b\u58eb\u5766\u4e01"
+    ],
+    "name:yue_x_preferred":[
         "\u541b\u58eb\u5766\u4e01"
     ],
     "name:zho_x_preferred":[
@@ -367,7 +412,7 @@
         }
     ],
     "wof:id":890439959,
-    "wof:lastmodified":1636501722,
+    "wof:lastmodified":1690875542,
     "wof:name":"Constantine",
     "wof:parent_id":85670855,
     "wof:placetype":"locality",

--- a/data/890/440/139/890440139.geojson
+++ b/data/890/440/139/890440139.geojson
@@ -28,11 +28,17 @@
     "name:arq_x_preferred":[
         "\u0639\u0646\u0627\u0628\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u0646\u0627\u0628\u0647"
+    ],
     "name:ast_x_preferred":[
         "Annaba"
     ],
     "name:azb_x_preferred":[
         "\u0639\u0646\u0627\u0628\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fnnab\u0259"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09a8\u09cd\u09a8\u09be\u09ac\u09be"
@@ -94,8 +100,20 @@
     "name:fra_x_variant":[
         "Annaba"
     ],
+    "name:frr_x_preferred":[
+        "Annaba"
+    ],
+    "name:fry_x_preferred":[
+        "Annaba"
+    ],
+    "name:gle_x_preferred":[
+        "Annaba"
+    ],
     "name:glg_x_preferred":[
         "Annaba - \u0633\u064a\u0627\u062d\u0629"
+    ],
+    "name:glg_x_variant":[
+        "Annaba"
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0aa8\u0acd\u0aa8\u0abe\u0aac\u0abe"
@@ -107,7 +125,8 @@
         "\u05d0\u05e0\u05d0\u05d1\u05d4"
     ],
     "name:heb_x_variant":[
-        "\u05e2\u05e0\u05d1\u05d4"
+        "\u05e2\u05e0\u05d1\u05d4",
+        "\u05e2\u05e0\u05d0\u05d1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0905\u0928\u094d\u0928\u093e\u092c\u093e"
@@ -120,6 +139,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0531\u0576\u0576\u0561\u0562\u0561"
+    ],
+    "name:ido_x_preferred":[
+        "Annaba"
     ],
     "name:ind_x_preferred":[
         "Annaba"
@@ -135,6 +157,9 @@
     ],
     "name:kan_x_preferred":[
         "\u0c85\u0ca8\u0cbe\u0cac\u0cbe"
+    ],
+    "name:kat_x_preferred":[
+        "\u10d0\u10dc\u10d0\u10d1\u10d0"
     ],
     "name:kaz_x_preferred":[
         "\u0410\u043d\u043d\u0430\u0431\u0430 \u049b\u0430\u043b\u0430\u0441\u044b"
@@ -154,11 +179,17 @@
     "name:lit_x_preferred":[
         "Anaba"
     ],
+    "name:ltz_x_preferred":[
+        "Annaba"
+    ],
     "name:mar_x_preferred":[
         "\u0905\u0928\u094d\u200d\u0928\u093e\u092c\u093e"
     ],
     "name:mkd_x_preferred":[
         "\u0410\u043d\u0430\u0431\u0430"
+    ],
+    "name:mlt_x_preferred":[
+        "Annaba"
     ],
     "name:msa_x_preferred":[
         "Annaba"
@@ -177,6 +208,12 @@
     ],
     "name:oci_x_preferred":[
         "Annaba"
+    ],
+    "name:oss_x_preferred":[
+        "\u0410\u043d\u043d\u0430\u0431\u00e6"
+    ],
+    "name:pan_x_preferred":[
+        "\u0a05\u0a70\u0a28\u0a3e\u0a2c\u0a3e"
     ],
     "name:pnb_x_preferred":[
         "\u0639\u0646\u0627\u0628\u06c1"
@@ -232,6 +269,9 @@
     "name:tur_x_preferred":[
         "Annaba"
     ],
+    "name:uig_x_preferred":[
+        "\u0626\u06d5\u0646\u0646\u0627\u0628\u06d5"
+    ],
     "name:ukr_x_preferred":[
         "\u0410\u043d\u043d\u0430\u0431\u0430"
     ],
@@ -244,11 +284,23 @@
     "name:uzb_x_preferred":[
         "Annaba"
     ],
+    "name:uzb_x_variant":[
+        "Annoba"
+    ],
+    "name:vec_x_preferred":[
+        "Annaba"
+    ],
     "name:vie_x_preferred":[
         "Annaba"
     ],
     "name:war_x_preferred":[
         "Annaba"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5b89\u7eb3\u5df4"
+    ],
+    "name:yue_x_preferred":[
+        "\u5b89\u7d0d\u5df4"
     ],
     "name:zho_x_preferred":[
         "\u5b89\u7eb3\u5df4"
@@ -376,7 +428,7 @@
         }
     ],
     "wof:id":890440139,
-    "wof:lastmodified":1636501721,
+    "wof:lastmodified":1690875540,
     "wof:name":"Annaba",
     "wof:parent_id":85670713,
     "wof:placetype":"locality",

--- a/data/890/440/141/890440141.geojson
+++ b/data/890/440/141/890440141.geojson
@@ -22,6 +22,15 @@
     "name:ara_x_preferred":[
         "\u062a\u0642\u0631\u062a"
     ],
+    "name:arq_x_preferred":[
+        "\u062a\u06a8\u0631\u062a"
+    ],
+    "name:arz_x_preferred":[
+        "\u062a\u0642\u0631\u062a"
+    ],
+    "name:ast_x_preferred":[
+        "Touggourt"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0642\u0648\u0631\u062a"
     ],
@@ -36,6 +45,9 @@
     ],
     "name:ceb_x_preferred":[
         "Touggourt"
+    ],
+    "name:ces_x_preferred":[
+        "Tukkurt"
     ],
     "name:dan_x_preferred":[
         "Touggourt"
@@ -56,7 +68,8 @@
         "\u062a\u0642\u0648\u0631\u062a\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
     ],
     "name:fas_x_variant":[
-        "\u062a\u0642\u0648\u0631\u062a"
+        "\u062a\u0642\u0648\u0631\u062a",
+        "\u062a\u0642\u0631\u062a"
     ],
     "name:fin_x_preferred":[
         "Touggourt"
@@ -84,6 +97,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30c8\u30a5\u30fc\u30b0\u30e9"
+    ],
+    "name:kab_x_preferred":[
+        "Tuggurt"
     ],
     "name:kan_x_preferred":[
         "\u0c9f\u0ccc\u0c97\u0ccd\u0cb5\u0cbe\u0cb0\u0ccd\u0c9f\u0ccd"
@@ -121,6 +137,9 @@
     "name:por_x_preferred":[
         "Touggourt"
     ],
+    "name:pus_x_preferred":[
+        "\u062a\u0648\u0642\u0631\u062a"
+    ],
     "name:ron_x_preferred":[
         "Touggourt"
     ],
@@ -132,6 +151,9 @@
     ],
     "name:spa_x_preferred":[
         "Touggourt"
+    ],
+    "name:spa_x_variant":[
+        "Tuggurt"
     ],
     "name:swe_x_preferred":[
         "Touggourt"
@@ -297,7 +319,7 @@
         }
     ],
     "wof:id":890440141,
-    "wof:lastmodified":1636501722,
+    "wof:lastmodified":1690875540,
     "wof:name":"Touggourt",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",

--- a/data/890/440/143/890440143.geojson
+++ b/data/890/440/143/890440143.geojson
@@ -25,6 +25,15 @@
     "name:arg_x_preferred":[
         "Termic\u00e9n"
     ],
+    "name:arq_x_preferred":[
+        "\u062a\u0644\u0645\u0633\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u062a\u0644\u0645\u0633\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Tlemcen"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0644\u0645\u0633\u0627\u0646"
     ],
@@ -73,6 +82,9 @@
     "name:fra_x_preferred":[
         "Tlemcen"
     ],
+    "name:gle_x_preferred":[
+        "Tlemcen"
+    ],
     "name:guj_x_preferred":[
         "\u0a9f\u0ab2\u0ac7\u0aae\u0acd\u0a95\u0ac7\u0aa8"
     ],
@@ -112,6 +124,9 @@
     "name:kor_x_preferred":[
         "\ud2c0\ub818\uc13c"
     ],
+    "name:kur_x_preferred":[
+        "Tlemsan"
+    ],
     "name:lat_x_preferred":[
         "Pomaria"
     ],
@@ -124,8 +139,14 @@
     "name:mar_x_preferred":[
         "\u091f\u0932\u0947\u092e\u0938\u0928"
     ],
+    "name:mdf_x_preferred":[
+        "\u0422\u043b\u044d\u043c\u0441\u044d\u043d"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u043b\u0435\u043c\u0441\u0435\u043d"
+    ],
+    "name:mlt_x_preferred":[
+        "Tlemcen"
     ],
     "name:msa_x_preferred":[
         "Tlemcen"
@@ -208,6 +229,9 @@
     "name:urd_x_preferred":[
         "\u062a\u0644\u0645\u0633\u0627\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Tlemcen"
+    ],
     "name:vie_x_preferred":[
         "Tlemcen"
     ],
@@ -216,6 +240,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7279\u83b1\u59c6\u68ee"
+    ],
+    "name:zul_x_preferred":[
+        "Tlemcen"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -343,7 +370,7 @@
         }
     ],
     "wof:id":890440143,
-    "wof:lastmodified":1636501721,
+    "wof:lastmodified":1690875540,
     "wof:name":"Tlemcen",
     "wof:parent_id":85670695,
     "wof:placetype":"locality",

--- a/data/890/440/309/890440309.geojson
+++ b/data/890/440/309/890440309.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0631\u0642\u0627\u0646"
     ],
+    "name:arq_x_preferred":[
+        "\u0631\u06a8\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0631\u0642\u0627\u0646"
+    ],
     "name:azb_x_preferred":[
         "\u0631\u0642\u0627\u0646"
+    ],
+    "name:aze_x_preferred":[
+        "R\u0259qqan"
     ],
     "name:ben_x_preferred":[
         "\u09b0\u09c7\u0997\u0997\u09be\u09a8\u09c7"
@@ -36,6 +45,9 @@
     ],
     "name:deu_x_preferred":[
         "Reggane"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a1\u03b5\u03b3\u03ba\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "Reggane"
@@ -60,6 +72,9 @@
     ],
     "name:hun_x_preferred":[
         "Reggane"
+    ],
+    "name:hye_x_preferred":[
+        "\u054c\u0565\u0563\u0563\u0561\u0576"
     ],
     "name:ind_x_preferred":[
         "Reggane"
@@ -109,6 +124,9 @@
     "name:tur_x_preferred":[
         "Reggane"
     ],
+    "name:ukr_x_preferred":[
+        "\u0420\u0435\u0433\u0433\u0430\u043d"
+    ],
     "name:und_x_variant":[
         "Zaouiet Reggane"
     ],
@@ -120,6 +138,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u7518"
+    ],
+    "name:zul_x_preferred":[
+        "Reggane"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -244,7 +265,7 @@
         }
     ],
     "wof:id":890440309,
-    "wof:lastmodified":1636501721,
+    "wof:lastmodified":1690875539,
     "wof:name":"Reggane",
     "wof:parent_id":85670677,
     "wof:placetype":"locality",

--- a/data/890/441/439/890441439.geojson
+++ b/data/890/441/439/890441439.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0645\u0627\u0644\u062d"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0645\u0627\u0644\u062d"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u0644\u062d"
     ],
@@ -58,6 +61,9 @@
     "name:nld_x_preferred":[
         "El Malah"
     ],
+    "name:pol_x_preferred":[
+        "El Malah"
+    ],
     "name:por_x_preferred":[
         "El Malah"
     ],
@@ -72,6 +78,9 @@
     ],
     "name:und_x_variant":[
         "Rio Salado"
+    ],
+    "name:uzb_x_preferred":[
+        "El Malah"
     ],
     "name:vie_x_preferred":[
         "El Malah"
@@ -110,7 +119,7 @@
         }
     ],
     "wof:id":890441439,
-    "wof:lastmodified":1566583508,
+    "wof:lastmodified":1690875541,
     "wof:name":"El Malah",
     "wof:parent_id":85670683,
     "wof:placetype":"locality",

--- a/data/890/442/517/890442517.geojson
+++ b/data/890/442/517/890442517.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0628\u0648\u0633\u064a\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0628\u0648\u0633\u064a\u0641"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0628\u0648\u0633\u06cc\u0641"
+    ],
+    "name:ceb_x_preferred":[
+        "'A\u00efn Boucif"
     ],
     "name:eng_x_preferred":[
         "A\u00efn Boucif"
@@ -36,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "A\u00efn Boucif"
+    ],
+    "name:kab_x_preferred":[
+        "\u0190in Busif"
     ],
     "name:msa_x_preferred":[
         "A\u00efn Boucif"
@@ -55,8 +64,14 @@
     "name:spa_x_preferred":[
         "A\u00efn Boucif"
     ],
+    "name:swe_x_preferred":[
+        "'A\u00efn Boucif"
+    ],
     "name:und_x_variant":[
         "Bordj A\u00efn Boucif"
+    ],
+    "name:uzb_x_preferred":[
+        "Ayn Busif"
     ],
     "name:vie_x_preferred":[
         "Ain Boucif"
@@ -95,7 +110,7 @@
         }
     ],
     "wof:id":890442517,
-    "wof:lastmodified":1566583515,
+    "wof:lastmodified":1690875550,
     "wof:name":"\u2019A\u00efn Boucif",
     "wof:parent_id":85670837,
     "wof:placetype":"locality",

--- a/data/890/442/519/890442519.geojson
+++ b/data/890/442/519/890442519.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0628\u0633\u0627\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0628\u0633\u0627\u0645"
+    ],
     "name:azb_x_preferred":[
         "\u0639\u06cc\u0646 \u0628\u0633\u0627\u0645"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:ita_x_preferred":[
         "A\u00efn Bessem"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30a4\u30f3\u30fb\u30d9\u30bb\u30e0"
     ],
     "name:kab_x_preferred":[
         "\u0190in Bessam"
@@ -76,11 +82,17 @@
     "name:urd_x_preferred":[
         "\u0639\u06cc\u0646-\u0628\u0633\u0627\u0645"
     ],
+    "name:uzb_x_preferred":[
+        "Ayn Bessem"
+    ],
     "name:vie_x_preferred":[
         "Ain-Bessem"
     ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u8c9d\u585e\u59c6"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Bessem"
     ],
     "qs:name":"A\u00efn Bessem",
     "qs:photos_9r":0,
@@ -113,7 +125,7 @@
         }
     ],
     "wof:id":890442519,
-    "wof:lastmodified":1566583515,
+    "wof:lastmodified":1690875550,
     "wof:name":"A\u00efn Bessem",
     "wof:parent_id":85670823,
     "wof:placetype":"locality",

--- a/data/890/444/469/890444469.geojson
+++ b/data/890/444/469/890444469.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0633\u0639\u064a\u062f\u0629"
     ],
+    "name:ary_x_preferred":[
+        "\u0633\u0639\u064a\u062f\u0629"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0639\u064a\u062f\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u0639\u06cc\u062f\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "S\u0259ida"
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09be\u09af\u09bc\u09a6\u09be"
@@ -40,6 +49,9 @@
     "name:deu_x_preferred":[
         "Saida"
     ],
+    "name:deu_x_variant":[
+        "Sa\u00efda"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03ac\u03b9\u03bd\u03c4\u03b1"
     ],
@@ -48,6 +60,9 @@
     ],
     "name:eng_x_preferred":[
         "Sa\u00efda"
+    ],
+    "name:eng_x_variant":[
+        "Saida"
     ],
     "name:epo_x_preferred":[
         "Saida"
@@ -67,6 +82,9 @@
     "name:guj_x_preferred":[
         "\u0ab8\u0a87\u0aa6\u0abe"
     ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05e2\u05d9\u05d3\u05d0"
+    ],
     "name:hin_x_preferred":[
         "\u0938\u0908\u0926\u093e"
     ],
@@ -81,6 +99,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30a4\u30c0"
+    ],
+    "name:kab_x_preferred":[
+        "Ss\u025bida"
     ],
     "name:kan_x_preferred":[
         "\u0cb8\u0cc8\u0ca6\u0cbe"
@@ -118,6 +139,9 @@
     "name:por_x_preferred":[
         "Saida"
     ],
+    "name:pus_x_preferred":[
+        "\u0633\u0639\u064a\u062f\u0647"
+    ],
     "name:ron_x_preferred":[
         "Sa\u00efda"
     ],
@@ -131,6 +155,9 @@
         "\u0dc3\u0dba\u0dd2\u0daf\u0dcf"
     ],
     "name:spa_x_preferred":[
+        "Sa\u00efda"
+    ],
+    "name:swa_x_preferred":[
         "Sa\u00efda"
     ],
     "name:swe_x_preferred":[
@@ -289,7 +316,7 @@
         }
     ],
     "wof:id":890444469,
-    "wof:lastmodified":1566583512,
+    "wof:lastmodified":1690875549,
     "wof:name":"Sa\u00efda",
     "wof:parent_id":85670797,
     "wof:placetype":"locality",

--- a/data/890/444/471/890444471.geojson
+++ b/data/890/444/471/890444471.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u062e\u0627\u0644\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u062e\u0627\u0644\u062f"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u062e\u0627\u0644\u062f"
     ],
@@ -39,6 +42,12 @@
     ],
     "name:ita_x_preferred":[
         "Sidi Khaled"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30c7\u30a3\u30fb\u30cf\u30ec\u30c9"
+    ],
+    "name:kab_x_preferred":[
+        "Sidi Xaled"
     ],
     "name:msa_x_preferred":[
         "Sidi Khaled"
@@ -65,6 +74,9 @@
         "Sidi Kraled"
     ],
     "name:vie_x_preferred":[
+        "Sidi Khaled"
+    ],
+    "name:zul_x_preferred":[
         "Sidi Khaled"
     ],
     "qs:name":"Sidi Khaled",
@@ -98,7 +110,7 @@
         }
     ],
     "wof:id":890444471,
-    "wof:lastmodified":1566583511,
+    "wof:lastmodified":1690875546,
     "wof:name":"Sidi Khaled",
     "wof:parent_id":85670827,
     "wof:placetype":"locality",

--- a/data/890/444/473/890444473.geojson
+++ b/data/890/444/473/890444473.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u062f\u064a \u0627\u0644\u0634\u062d\u0645\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u062f\u0649 \u0627\u0644\u0634\u062d\u0645\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0633\u06cc\u062f\u06cc \u0634\u062d\u0645\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "Sidi-\u015e\u0259mi"
     ],
     "name:ceb_x_preferred":[
         "Sidi ech Chahmi"
@@ -39,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Sidi Chami"
+    ],
+    "name:kab_x_preferred":[
+        "Sidi Cce\u1e25mi"
     ],
     "name:msa_x_preferred":[
         "Sidi Chami"
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":890444473,
-    "wof:lastmodified":1566583512,
+    "wof:lastmodified":1690875548,
     "wof:name":"Sidi ech Chahmi",
     "wof:parent_id":85670689,
     "wof:placetype":"locality",

--- a/data/890/444/477/890444477.geojson
+++ b/data/890/444/477/890444477.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0623\u0645 \u0627\u0644\u0628\u0648\u0627\u0642\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0645 \u0627\u0644\u0628\u0648\u0627\u0642\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Oum El Bouaghi"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0645 \u0628\u0648\u0627\u0642\u06cc"
+    ],
+    "name:aze_x_preferred":[
+        "Umm-\u0259l-Buaqi"
     ],
     "name:ben_x_preferred":[
         "\u0994\u09ae \u098f\u09b2 \u09ac\u09cc\u09df\u09be\u0998\u09bf"
@@ -33,6 +42,9 @@
     ],
     "name:deu_x_preferred":[
         "Oum el Bouaghi"
+    ],
+    "name:ell_x_preferred":[
+        "\u039f\u03c5\u03bc \u0395\u03bb \u039c\u03c0\u03bf\u03c5\u03b1\u03b3\u03ba\u03af"
     ],
     "name:eng_x_preferred":[
         "Oum El Bouaghi"
@@ -121,6 +133,9 @@
     "name:urd_x_preferred":[
         "\u0627\u0645 \u0627\u0644\u0628\u0648\u0627\u0642\u06cc"
     ],
+    "name:uzb_x_preferred":[
+        "Oum El Bouaghi"
+    ],
     "name:vie_x_preferred":[
         "Oum El Bouaghi"
     ],
@@ -129,6 +144,9 @@
     ],
     "name:zho_x_preferred":[
         "\u70cf\u59c6\u5e03\u74e6\u5409"
+    ],
+    "name:zul_x_preferred":[
+        "Oum El Bouaghi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -255,7 +273,7 @@
         }
     ],
     "wof:id":890444477,
-    "wof:lastmodified":1636501722,
+    "wof:lastmodified":1690875547,
     "wof:name":"Oum el Bouaghi",
     "wof:parent_id":85670871,
     "wof:placetype":"locality",

--- a/data/890/444/479/890444479.geojson
+++ b/data/890/444/479/890444479.geojson
@@ -22,11 +22,20 @@
     "name:ara_x_preferred":[
         "\u0648\u0631\u0642\u0644\u0629"
     ],
+    "name:arq_x_preferred":[
+        "\u0648\u0631\u06a8\u0644\u0629"
+    ],
     "name:arz_x_preferred":[
         "\u0648\u0631\u0642\u0644\u0629"
     ],
+    "name:ast_x_preferred":[
+        "Ouargla"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0631\u0642\u0644\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "Uarqla"
     ],
     "name:ben_x_preferred":[
         "\u0993\u09af\u09bc\u09be\u0997\u09cd\u09b2\u09be"
@@ -46,11 +55,17 @@
     "name:ell_x_preferred":[
         "\u039f\u03c5\u03ad\u03c1\u03b3\u03ba\u03bb\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u039f\u03c5\u03ac\u03c1\u03b3\u03ba\u03bb\u03b1"
+    ],
     "name:eng_x_preferred":[
         "Ouargla"
     ],
     "name:epo_x_preferred":[
         "Uargla"
+    ],
+    "name:eus_x_preferred":[
+        "Ouargla"
     ],
     "name:fas_x_preferred":[
         "\u0648\u0631\u0642\u0644\u0647\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -76,6 +91,9 @@
     "name:hun_x_preferred":[
         "Ouargla"
     ],
+    "name:hye_x_preferred":[
+        "\u0548\u0582\u0561\u0580\u0563\u056c\u0561"
+    ],
     "name:ind_x_preferred":[
         "Ouargla"
     ],
@@ -84,6 +102,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ef\u30eb\u30b0\u30e9"
+    ],
+    "name:kab_x_preferred":[
+        "Wergla"
     ],
     "name:kan_x_preferred":[
         "\u0c93\u0cb0\u0ccd\u0c97\u0cbe\u0cb2\u0cbe"
@@ -137,6 +158,12 @@
         "\u0d96\u0dbb\u0dca\u0da2\u0dd2\u0d86"
     ],
     "name:spa_x_preferred":[
+        "Ouargla"
+    ],
+    "name:spa_x_variant":[
+        "Uargla"
+    ],
+    "name:swa_x_preferred":[
         "Ouargla"
     ],
     "name:swe_x_preferred":[
@@ -297,7 +324,7 @@
         }
     ],
     "wof:id":890444479,
-    "wof:lastmodified":1636501722,
+    "wof:lastmodified":1690875547,
     "wof:name":"Ouargla",
     "wof:parent_id":85670759,
     "wof:placetype":"locality",

--- a/data/890/444/481/890444481.geojson
+++ b/data/890/444/481/890444481.geojson
@@ -22,11 +22,20 @@
     "name:ara_x_preferred":[
         "\u0645\u0633\u062a\u063a\u0627\u0646\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0633\u062a\u062c\u0627\u0646\u0645"
+    ],
+    "name:ast_x_preferred":[
+        "Mostaganem"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0633\u062a\u063a\u0627\u0646\u0645"
     ],
     "name:aze_x_preferred":[
         "Mostaqanem"
+    ],
+    "name:bel_x_preferred":[
+        "\u041c\u0430\u0441\u0442\u0430\u0433\u0430\u043d\u0435\u043c"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09cb\u09b8\u09cd\u09a4\u09be\u0997\u09be\u09a8\u09c7\u09ae"
@@ -130,6 +139,9 @@
     "name:nob_x_preferred":[
         "Mostaganem"
     ],
+    "name:oss_x_preferred":[
+        "\u041c\u043e\u0441\u0442\u0430\u0433\u0430\u043d\u0435\u043c"
+    ],
     "name:pnb_x_preferred":[
         "\u0645\u0633\u062a\u0627\u063a\u0627\u0646\u0645"
     ],
@@ -156,6 +168,9 @@
     ],
     "name:srp_x_preferred":[
         "\u041c\u043e\u0441\u0442\u0430\u0433\u0430\u043d\u0435\u043c"
+    ],
+    "name:swa_x_preferred":[
+        "Mostaganem"
     ],
     "name:swe_x_preferred":[
         "Mostaganem"
@@ -315,7 +330,7 @@
         }
     ],
     "wof:id":890444481,
-    "wof:lastmodified":1636501723,
+    "wof:lastmodified":1690875548,
     "wof:name":"Mostaganem",
     "wof:parent_id":85670787,
     "wof:placetype":"locality",

--- a/data/890/444/483/890444483.geojson
+++ b/data/890/444/483/890444483.geojson
@@ -22,11 +22,23 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0646\u0639\u0627\u0645\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0646\u0639\u0627\u0645\u0647"
+    ],
     "name:azb_x_preferred":[
         "\u0646\u0639\u0627\u0645\u0647"
     ],
+    "name:aze_x_preferred":[
+        "N\u0259ama"
+    ],
+    "name:cat_x_preferred":[
+        "Na\u00e2ma"
+    ],
     "name:ceb_x_preferred":[
         "Naama"
+    ],
+    "name:ell_x_preferred":[
+        "\u039d\u03b1\u03ac\u03bc\u03b1"
     ],
     "name:eng_x_preferred":[
         "Na\u00e2ma"
@@ -34,11 +46,20 @@
     "name:fas_x_preferred":[
         "\u0646\u0639\u0627\u0645\u0647"
     ],
+    "name:fin_x_preferred":[
+        "Na\u00e2ma"
+    ],
     "name:fra_x_preferred":[
         "Na\u00e2ma"
     ],
     "name:ita_x_preferred":[
         "Na\u00e2ma"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ca\u30fc\u30de"
+    ],
+    "name:kab_x_preferred":[
+        "Nn\u025bama"
     ],
     "name:kor_x_preferred":[
         "\ub098\ub9c8"
@@ -108,7 +129,7 @@
         }
     ],
     "wof:id":890444483,
-    "wof:lastmodified":1566583511,
+    "wof:lastmodified":1690875547,
     "wof:name":"Naama",
     "wof:parent_id":85670707,
     "wof:placetype":"locality",

--- a/data/890/444/485/890444485.geojson
+++ b/data/890/444/485/890444485.geojson
@@ -22,8 +22,17 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0623\u063a\u0648\u0627\u0637"
     ],
+    "name:arq_x_preferred":[
+        "\u0627\u0644\u0623\u063a\u0648\u0627\u0637"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0627\u063a\u0648\u0627\u0637"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0644\u0627\u063a\u0648\u0627\u0637"
+    ],
+    "name:aze_x_preferred":[
+        "L\u0259\u011fuat"
     ],
     "name:ben_x_preferred":[
         "\u09b2\u09be\u0997\u09b9\u09c1\u09af\u09bc\u09be"
@@ -49,8 +58,14 @@
     "name:eng_x_preferred":[
         "Laghouat"
     ],
+    "name:eng_x_variant":[
+        "Laghouat Province"
+    ],
     "name:epo_x_preferred":[
         "Laghuat"
+    ],
+    "name:eus_x_preferred":[
+        "Laghouat"
     ],
     "name:fas_x_preferred":[
         "\u0627\u0644\u0627\u063a\u0648\u0627\u0637\u060c \u0627\u0644\u062c\u0632\u0627\u06cc\u0631"
@@ -62,6 +77,9 @@
         "Laghouat"
     ],
     "name:fra_x_preferred":[
+        "Laghouat"
+    ],
+    "name:glg_x_preferred":[
         "Laghouat"
     ],
     "name:guj_x_preferred":[
@@ -90,6 +108,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30e9\u30b0\u30a2\u30c3\u30c8"
+    ],
+    "name:kab_x_preferred":[
+        "Le\u0263wa\u1e6d"
     ],
     "name:kan_x_preferred":[
         "\u0cb2\u0c98\u0cc1\u0ca4\u0ccd"
@@ -142,6 +163,12 @@
     "name:spa_x_preferred":[
         "Laghouat"
     ],
+    "name:srp_x_preferred":[
+        "\u041b\u0430\u0433\u0443\u0430\u0442"
+    ],
+    "name:swa_x_preferred":[
+        "Laghouat"
+    ],
     "name:swe_x_preferred":[
         "Laghouat"
     ],
@@ -174,6 +201,9 @@
     ],
     "name:zho_x_preferred":[
         "\u827e\u683c\u74e6\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Laghouat"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -298,7 +328,7 @@
         }
     ],
     "wof:id":890444485,
-    "wof:lastmodified":1636501722,
+    "wof:lastmodified":1690875546,
     "wof:name":"Laghouat",
     "wof:parent_id":85670753,
     "wof:placetype":"locality",

--- a/data/890/444/487/890444487.geojson
+++ b/data/890/444/487/890444487.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_variant":[
         "\u0625\u0644\u064a\u0632\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u064a\u0632\u0649"
+    ],
+    "name:aze_x_preferred":[
+        "\u0130llizi"
+    ],
     "name:ben_x_preferred":[
         "\u0987\u09b2\u09cd\u09b2\u09bf\u099c\u09bf"
     ],
@@ -36,6 +42,9 @@
     ],
     "name:deu_x_preferred":[
         "Illizi"
+    ],
+    "name:ell_x_preferred":[
+        "\u0399\u03bb\u03b9\u03b6\u03af"
     ],
     "name:eng_x_preferred":[
         "Illizi"
@@ -66,6 +75,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a4\u30ea\u30b8"
+    ],
+    "name:kab_x_preferred":[
+        "Illizi"
     ],
     "name:kor_x_preferred":[
         "\uc77c\ub9ac\uc9c0"
@@ -253,7 +265,7 @@
         }
     ],
     "wof:id":890444487,
-    "wof:lastmodified":1636501723,
+    "wof:lastmodified":1690875548,
     "wof:name":"Illizi",
     "wof:parent_id":85670731,
     "wof:placetype":"locality",

--- a/data/890/444/489/890444489.geojson
+++ b/data/890/444/489/890444489.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0643\u0631\u0643\u0631\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0643\u0631\u0643\u0631\u0647"
+    ],
     "name:ceb_x_preferred":[
         "Kerkera"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:kab_x_preferred":[
         "Kerkera"
+    ],
+    "name:kab_x_variant":[
+        "Kerkra"
     ],
     "name:msa_x_preferred":[
         "Kerkera"
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":890444489,
-    "wof:lastmodified":1566583512,
+    "wof:lastmodified":1690875548,
     "wof:name":"Kerkera",
     "wof:parent_id":85670727,
     "wof:placetype":"locality",

--- a/data/890/444/491/890444491.geojson
+++ b/data/890/444/491/890444491.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0631\u064a\u0632\u064a\u0646\u0629"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0631\u064a\u0632\u064a\u0646\u0647"
+    ],
+    "name:ast_x_preferred":[
+        "Brezina"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u06cc\u0632\u06cc\u0646\u0647"
     ],
@@ -31,6 +37,9 @@
     "name:eng_x_preferred":[
         "Br\u00e9zina"
     ],
+    "name:eng_x_variant":[
+        "Brezina"
+    ],
     "name:fas_x_preferred":[
         "\u0628\u0631\u06cc\u0632\u06cc\u0646\u0647"
     ],
@@ -39,6 +48,9 @@
     ],
     "name:ita_x_preferred":[
         "Brezina"
+    ],
+    "name:kab_x_preferred":[
+        "Brizina"
     ],
     "name:msa_x_preferred":[
         "Br\u00e9zina"
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":890444491,
-    "wof:lastmodified":1566583512,
+    "wof:lastmodified":1690875548,
     "wof:name":"Brezina",
     "wof:parent_id":85670741,
     "wof:placetype":"locality",

--- a/data/890/444/495/890444495.geojson
+++ b/data/890/444/495/890444495.geojson
@@ -25,14 +25,26 @@
     "name:arg_x_preferred":[
         "Boch\u00eda"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u062c\u0627\u064a\u0629\u200e"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u062c\u0627\u064a\u0647"
+    ],
     "name:ast_x_preferred":[
         "B\u00e9ja\u00efa"
+    ],
+    "name:aze_x_preferred":[
+        "Becaya"
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u099c\u09be\u09b0\u09be"
     ],
     "name:bre_x_preferred":[
         "Beja\u00efa"
+    ],
+    "name:bre_x_variant":[
+        "Bejaia"
     ],
     "name:bul_x_preferred":[
         "\u0411\u0435\u0434\u0436\u0430\u044f"
@@ -49,6 +61,9 @@
     "name:ces_x_preferred":[
         "Bid\u017e\u00e1ja"
     ],
+    "name:cos_x_preferred":[
+        "B\u00e9ja\u00efa"
+    ],
     "name:dan_x_preferred":[
         "B\u00e9ja\u00efa"
     ],
@@ -62,7 +77,8 @@
         "B\u00e9ja\u00efa"
     ],
     "name:eng_x_variant":[
-        "Beja\u00efa"
+        "Beja\u00efa",
+        "Bejaia"
     ],
     "name:epo_x_preferred":[
         "Be\u0135aja"
@@ -88,6 +104,12 @@
     "name:fra_x_variant":[
         "B\u00e9ja\u00efa"
     ],
+    "name:gle_x_preferred":[
+        "B\u00e9ja\u00efa"
+    ],
+    "name:grc_x_preferred":[
+        "\u03a3\u03ac\u03bb\u03b4\u03b1\u03b9"
+    ],
     "name:guj_x_preferred":[
         "\u0aac\u0ac7\u0a9c\u0abe\u0a88\u0aaf\u0abe"
     ],
@@ -96,6 +118,9 @@
     ],
     "name:hin_x_preferred":[
         "\u092c\u0947\u091c\u093e\u0907\u0906"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u0565\u057b\u0561\u0575\u0561"
     ],
     "name:ind_x_preferred":[
         "B\u00e9ja\u00efa"
@@ -172,6 +197,9 @@
     "name:scn_x_preferred":[
         "B\u00e9ja\u00efa"
     ],
+    "name:sco_x_preferred":[
+        "B\u00e9ja\u00efa"
+    ],
     "name:sin_x_preferred":[
         "\u0db6\u0dd9\u0da2\u0dba\u0dcf"
     ],
@@ -183,6 +211,9 @@
     ],
     "name:srp_x_preferred":[
         "Bed\u017eaja"
+    ],
+    "name:swa_x_preferred":[
+        "B\u00e9ja\u00efa"
     ],
     "name:swe_x_preferred":[
         "Beja\u00efa"
@@ -205,11 +236,17 @@
     "name:tur_x_preferred":[
         "B\u00e9jaia"
     ],
+    "name:tur_x_variant":[
+        "Bic\u00e2ye"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u0434\u0436\u0430\u044f"
     ],
     "name:urd_x_preferred":[
         "\u0628\u062c\u0627\u06cc\u06c1"
+    ],
+    "name:vec_x_preferred":[
+        "B\u00e9ja\u00efa"
     ],
     "name:vie_x_preferred":[
         "B\u00e9ja\u00efa"
@@ -219,6 +256,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8d1d\u8d3e\u4e9a"
+    ],
+    "name:zul_x_preferred":[
+        "B\u00e9ja\u00efa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Algeria",
@@ -343,7 +383,7 @@
         }
     ],
     "wof:id":890444495,
-    "wof:lastmodified":1566583513,
+    "wof:lastmodified":1690875549,
     "wof:name":"Beja\u00efa",
     "wof:parent_id":85670815,
     "wof:placetype":"locality",

--- a/data/890/444/497/890444497.geojson
+++ b/data/890/444/497/890444497.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0639\u064a\u0646 \u0641\u0643\u0631\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0639\u064a\u0646 \u0641\u0643\u0631\u0648\u0646"
+    ],
     "name:ceb_x_preferred":[
         "A\u00efn Fakroun"
     ],
@@ -40,6 +43,12 @@
     "name:kab_x_preferred":[
         "Tifkert"
     ],
+    "name:kab_x_variant":[
+        "Ifker"
+    ],
+    "name:kor_x_preferred":[
+        "\uc544\uc778 \ud30c\ud06c\ub8ec"
+    ],
     "name:msa_x_preferred":[
         "A\u00efn Fakroun"
     ],
@@ -49,10 +58,16 @@
     "name:nld_x_preferred":[
         "A\u00efn Fakroun"
     ],
+    "name:pol_x_preferred":[
+        "Ajn Fakrun"
+    ],
     "name:por_x_preferred":[
         "A\u00efn Fakroun"
     ],
     "name:ron_x_preferred":[
+        "A\u00efn Fakroun"
+    ],
+    "name:swa_x_preferred":[
         "A\u00efn Fakroun"
     ],
     "name:swe_x_preferred":[
@@ -66,6 +81,9 @@
     ],
     "name:zho_x_preferred":[
         "\u827e\u56e0\u6cd5\u514b\u9686"
+    ],
+    "name:zul_x_preferred":[
+        "A\u00efn Fakroun"
     ],
     "qs:name":"A\u00efn Fakroun",
     "qs:photos_9r":0,
@@ -98,7 +116,7 @@
         }
     ],
     "wof:id":890444497,
-    "wof:lastmodified":1566583511,
+    "wof:lastmodified":1690875547,
     "wof:name":"A\u00efn Fakroun",
     "wof:parent_id":85670871,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.