### PR TITLE
dz concordances, placetype local, and more

### DIFF
--- a/data/856/324/51/85632451.geojson
+++ b/data/856/324/51/85632451.geojson
@@ -1296,6 +1296,7 @@
         "hasc:id":"DZ",
         "icao:code":"7T",
         "ioc:id":"ALG",
+        "iso:code":"DZ",
         "itu:id":"ALG",
         "loc:id":"n79064760",
         "m49:code":"012",
@@ -1310,6 +1311,7 @@
         "wk:page":"Algeria",
         "wmo:id":"AL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
     "wof:country_alpha3":"DZA",
     "wof:geom_alt":[
@@ -1332,7 +1334,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1694639541,
+    "wof:lastmodified":1695881198,
     "wof:name":"Algeria",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/706/77/85670677.geojson
+++ b/data/856/706/77/85670677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":42.805629,
-    "geom:area_square_m":476316718319.953125,
+    "geom:area_square_m":476316713773.768127,
     "geom:bbox":"-5.661525,18.975561,3.790291,31.658585",
     "geom:latitude":25.703585,
     "geom:longitude":-0.443128,
@@ -405,13 +405,15 @@
         "gn:id":2508807,
         "gp:id":2344604,
         "hasc:id":"DZ.AR",
+        "iso:code":"DZ-01",
         "iso:id":"DZ-01",
         "qs_pg:id":890532,
         "unlc:id":"DZ-01",
         "wd:id":"Q188166"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"d167ce6b03529143b75f567fe9192758",
+    "wof:geomhash":"7c0e904481de55e9fc544ea254f526ae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -428,7 +430,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875490,
+    "wof:lastmodified":1695884902,
     "wof:name":"Adrar",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/83/85670683.geojson
+++ b/data/856/706/83/85670683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.194027,
-    "geom:area_square_m":1957228843.986336,
+    "geom:area_square_m":1957228464.972234,
     "geom:bbox":"-1.361976,35.087393,-0.629491,35.623242",
     "geom:latitude":35.335109,
     "geom:longitude":-1.030831,
@@ -347,14 +347,16 @@
         "gn:id":2507899,
         "gp:id":2344606,
         "hasc:id":"DZ.AT",
+        "iso:code":"DZ-46",
         "iso:id":"DZ-46",
         "qs_pg:id":268608,
         "unlc:id":"DZ-46",
         "wd:id":"Q233670",
         "wk:page":"A\u00efn T\u00e9mouchent Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"4b2ae58a3b161886782d903052282c75",
+    "wof:geomhash":"b300866b5015135ece6bb6167dd10e42",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -371,7 +373,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875490,
+    "wof:lastmodified":1695884479,
     "wof:name":"A\u00efn T\u00e9mouchent",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/89/85670689.geojson
+++ b/data/856/706/89/85670689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.24994,
-    "geom:area_square_m":2511998753.266726,
+    "geom:area_square_m":2511999820.440192,
     "geom:bbox":"-1.106344,35.294538,-0.113674,35.90705",
     "geom:latitude":35.629657,
     "geom:longitude":-0.632057,
@@ -353,13 +353,15 @@
         "gn:id":2485920,
         "gp:id":2344584,
         "hasc:id":"DZ.OR",
+        "iso:code":"DZ-31",
         "iso:id":"DZ-31",
         "qs_pg:id":221715,
         "unlc:id":"DZ-31",
         "wd:id":"Q231331"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"ed07eb100bbe4febe458445205caca7e",
+    "wof:geomhash":"9dc98e87f01ad60c90015d2bea6b5fe5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -376,7 +378,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875489,
+    "wof:lastmodified":1695884902,
     "wof:name":"Oran",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/91/85670691.geojson
+++ b/data/856/706/91/85670691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.752372,
-    "geom:area_square_m":7640540346.292261,
+    "geom:area_square_m":7640542714.384405,
     "geom:bbox":"-1.120417,34.215121,-0.052575,35.429388",
     "geom:latitude":34.789479,
     "geom:longitude":-0.565931,
@@ -323,13 +323,15 @@
         "gn:id":2481001,
         "gp:id":2344601,
         "hasc:id":"DZ.SB",
+        "iso:code":"DZ-22",
         "iso:id":"DZ-22",
         "qs_pg:id":57196,
         "unlc:id":"DZ-22",
         "wd:id":"Q235714"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"0212e021ccd61df489429c40ffc4e81c",
+    "wof:geomhash":"825e5bc10bf124310e7aec4997f344bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -346,7 +348,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875489,
+    "wof:lastmodified":1695884479,
     "wof:name":"Sidi Bel Abbes",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/95/85670695.geojson
+++ b/data/856/706/95/85670695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.940572,
-    "geom:area_square_m":9557849958.024862,
+    "geom:area_square_m":9557849645.993521,
     "geom:bbox":"-2.222564,34.092021,-0.758475,35.319899",
     "geom:latitude":34.733678,
     "geom:longitude":-1.422383,
@@ -420,13 +420,15 @@
         "gn:id":2475683,
         "gp:id":2344589,
         "hasc:id":"DZ.TL",
+        "iso:code":"DZ-13",
         "iso:id":"DZ-13",
         "qs_pg:id":399886,
         "unlc:id":"DZ-13",
         "wd:id":"Q233632"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"38cd651a3b6736ae391bcbe63dfe5e43",
+    "wof:geomhash":"0204099521ea0c28788898c9072b64b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -443,7 +445,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875489,
+    "wof:lastmodified":1695884902,
     "wof:name":"Tlemcen",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/706/99/85670699.geojson
+++ b/data/856/706/99/85670699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":15.46183,
-    "geom:area_square_m":165328310814.55722,
+    "geom:area_square_m":165328301116.52774,
     "geom:bbox":"-6.000765,28.207245,0.399128,32.327304",
     "geom:latitude":30.146045,
     "geom:longitude":-2.559673,
@@ -335,14 +335,16 @@
         "gn:id":2505525,
         "gp:id":2344608,
         "hasc:id":"DZ.BC",
+        "iso:code":"DZ-08",
         "iso:id":"DZ-08",
         "qs_pg:id":423533,
         "unlc:id":"DZ-08",
         "wd:id":"Q215467",
         "wk:page":"B\u00e9char Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"39c87fbfb8be8d150ae6e00d31a5b401",
+    "wof:geomhash":"f542902561c06b1cebf5cedc78cb31bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -359,7 +361,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875490,
+    "wof:lastmodified":1695884481,
     "wof:name":"B\u00e9char",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/07/85670707.geojson
+++ b/data/856/707/07/85670707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.978443,
-    "geom:area_square_m":30790065960.493397,
+    "geom:area_square_m":30790060511.874695,
     "geom:bbox":"-1.746788,32.10463,0.086021,34.31372",
     "geom:latitude":33.274457,
     "geom:longitude":-0.782387,
@@ -334,13 +334,15 @@
         "gn:id":2486512,
         "gp:id":2344619,
         "hasc:id":"DZ.NA",
+        "iso:code":"DZ-45",
         "iso:id":"DZ-45",
         "qs_pg:id":1134898,
         "unlc:id":"DZ-45",
         "wd:id":"Q233675"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"7a0e0350a78c5c2cc9d8318d052b14e1",
+    "wof:geomhash":"e2e0c73e8019577555262d5048131076",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -357,7 +359,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875498,
+    "wof:lastmodified":1695884479,
     "wof:name":"Naama",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/09/85670709.geojson
+++ b/data/856/707/09/85670709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.943876,
-    "geom:area_square_m":152783325657.715546,
+    "geom:area_square_m":152783333876.206696,
     "geom:bbox":"-8.682385,25.508881,-2.974257,29.579127",
     "geom:latitude":27.622506,
     "geom:longitude":-6.095668,
@@ -399,13 +399,15 @@
         "gn:id":2476302,
         "gp:id":2344624,
         "hasc:id":"DZ.TN",
+        "iso:code":"DZ-37",
         "iso:id":"DZ-37",
         "qs_pg:id":1134900,
         "unlc:id":"DZ-37",
         "wd:id":"Q231151"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"5ed5e6c7f10ab9712680c35d3fc5f37a",
+    "wof:geomhash":"09f4b0c9cb683b28994c9d1fb54ce3ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -422,7 +424,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875498,
+    "wof:lastmodified":1695884902,
     "wof:name":"Tindouf",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/13/85670713.geojson
+++ b/data/856/707/13/85670713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147509,
-    "geom:area_square_m":1459401567.730841,
+    "geom:area_square_m":1459400668.998469,
     "geom:bbox":"7.262677,36.612443,7.798595,37.082994",
     "geom:latitude":36.85893,
     "geom:longitude":7.530105,
@@ -432,13 +432,15 @@
         "gn:id":2506994,
         "gp:id":2344607,
         "hasc:id":"DZ.AN",
+        "iso:code":"DZ-23",
         "iso:id":"DZ-23",
         "qs_pg:id":362602,
         "unlc:id":"DZ-23",
         "wd:id":"Q213944"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"6ca9672b97566066adff11997ebce069",
+    "wof:geomhash":"e6ba14341fafd6859087bf08b7a8badd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -455,7 +457,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875502,
+    "wof:lastmodified":1695884903,
     "wof:name":"Annaba",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/19/85670719.geojson
+++ b/data/856/707/19/85670719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.275706,
-    "geom:area_square_m":2732588345.340635,
+    "geom:area_square_m":2732590237.338462,
     "geom:bbox":"7.649745,36.404135,8.642552,36.958075",
     "geom:latitude":36.722264,
     "geom:longitude":8.117478,
@@ -356,13 +356,15 @@
         "gn:id":2497322,
         "gp:id":2344614,
         "hasc:id":"DZ.ET",
+        "iso:code":"DZ-36",
         "iso:id":"DZ-36",
         "qs_pg:id":985922,
         "unlc:id":"DZ-36",
         "wd:id":"Q236788"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"1ed8e0a2ec48dfae2f94e5c85e7d6be0",
+    "wof:geomhash":"8b03c7be32e2ec245223737c08b3e007",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -379,7 +381,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875497,
+    "wof:lastmodified":1695884902,
     "wof:name":"El Tarf",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/23/85670723.geojson
+++ b/data/856/707/23/85670723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242723,
-    "geom:area_square_m":2406326060.044773,
+    "geom:area_square_m":2406325118.41562,
     "geom:bbox":"5.427349,36.523972,6.478499,36.935315",
     "geom:latitude":36.701491,
     "geom:longitude":5.961302,
@@ -366,13 +366,15 @@
         "gn:id":2492910,
         "gp:id":2344596,
         "hasc:id":"DZ.JJ",
+        "iso:code":"DZ-18",
         "iso:id":"DZ-18",
         "qs_pg:id":1134892,
         "unlc:id":"DZ-18",
         "wd:id":"Q235718"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"3590235796f7d57fa08ce2acd14c8a36",
+    "wof:geomhash":"29a7aa725e1b36805bc87cb34bfa3885",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -389,7 +391,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875500,
+    "wof:lastmodified":1695884903,
     "wof:name":"Jijel",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/27/85670727.geojson
+++ b/data/856/707/27/85670727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.413586,
-    "geom:area_square_m":4095963178.070495,
+    "geom:area_square_m":4095963415.601374,
     "geom:bbox":"6.247831,36.432867,7.384232,37.09394",
     "geom:latitude":36.781564,
     "geom:longitude":6.812256,
@@ -314,13 +314,15 @@
         "gn:id":2479532,
         "gp:id":2344602,
         "hasc:id":"DZ.SK",
+        "iso:code":"DZ-21",
         "iso:id":"DZ-21",
         "qs_pg:id":424927,
         "unlc:id":"DZ-21",
         "wd:id":"Q234227"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"7a9ec3704b2693cefae63f69dca4116b",
+    "wof:geomhash":"e5a420d4578801f56a920bffcd06fa59",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875497,
+    "wof:lastmodified":1695884902,
     "wof:name":"Skikda",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/31/85670731.geojson
+++ b/data/856/707/31/85670731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":17.807448,
-    "geom:area_square_m":196449686060.763214,
+    "geom:area_square_m":196449690536.421814,
     "geom:bbox":"5.815749,24.000137,11.71014,30.022794",
     "geom:latitude":26.795661,
     "geom:longitude":8.353429,
@@ -363,13 +363,15 @@
         "gn:id":2493455,
         "gp:id":2344616,
         "hasc:id":"DZ.IL",
+        "iso:code":"DZ-33",
         "iso:id":"DZ-33",
         "qs_pg:id":1134895,
         "unlc:id":"DZ-33",
         "wd:id":"Q233659"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"6dc0ceba4d60c58525251a40fdd16ac6",
+    "wof:geomhash":"8e6a266e2109dea60da09c2cc1099676",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -386,7 +388,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875499,
+    "wof:lastmodified":1695884902,
     "wof:name":"Illizi",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/35/85670735.geojson
+++ b/data/856/707/35/85670735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":54.093595,
-    "geom:area_square_m":610711320484.55481,
+    "geom:area_square_m":610711333962.157837,
     "geom:bbox":"0.825407,19.06077,11.968861,29.123546",
     "geom:latitude":23.972826,
     "geom:longitude":5.116536,
@@ -340,13 +340,15 @@
         "gn:id":2478217,
         "gp:id":2344623,
         "hasc:id":"DZ.TM",
+        "iso:code":"DZ-11",
         "iso:id":"DZ-11",
         "qs_pg:id":423540,
         "wd:id":"Q229467",
         "wk:page":"Tamanrasset Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"80f0fb9f54139a450d3ee66beadb5a65",
+    "wof:geomhash":"9083609324b5a3fe06cb30a8e2dc0960",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -363,7 +365,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875496,
+    "wof:lastmodified":1695884902,
     "wof:name":"Tamanghasset",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/41/85670741.geojson
+++ b/data/856/707/41/85670741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.566718,
-    "geom:area_square_m":68421118903.075432,
+    "geom:area_square_m":68421117264.003105,
     "geom:bbox":"-0.401133,30.708694,2.344849,34.438182",
     "geom:latitude":32.570439,
     "geom:longitude":0.9414,
@@ -354,13 +354,15 @@
         "gn:id":2498541,
         "gp:id":2344612,
         "hasc:id":"DZ.EB",
+        "iso:code":"DZ-32",
         "iso:id":"DZ-32",
         "qs_pg:id":1063253,
         "unlc:id":"DZ-32",
         "wd:id":"Q235703"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"7e6c1e25137d807e12400b6146efb405",
+    "wof:geomhash":"c5f16d08800c5eef4ca4da2064dbaab9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -377,7 +379,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875500,
+    "wof:lastmodified":1695884903,
     "wof:name":"El Bayadh",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/45/85670745.geojson
+++ b/data/856/707/45/85670745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.483506,
-    "geom:area_square_m":46375252720.607979,
+    "geom:area_square_m":46375246379.464485,
     "geom:bbox":"5.008046,32.000192,9.063304,34.499807",
     "geom:latitude":33.222433,
     "geom:longitude":6.957223,
@@ -381,13 +381,15 @@
         "gn:id":2497406,
         "gp:id":2344613,
         "hasc:id":"DZ.EO",
+        "iso:code":"DZ-39",
         "iso:id":"DZ-39",
         "qs_pg:id":237282,
         "unlc:id":"DZ-39",
         "wd:id":"Q233651"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"6a212332e2eb976a6fae394049d1b7f2",
+    "wof:geomhash":"7ac2bca87cda666a1cbcbaa2e99bb411",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -404,7 +406,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875497,
+    "wof:lastmodified":1695884902,
     "wof:name":"El Oued",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/49/85670749.geojson
+++ b/data/856/707/49/85670749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.142433,
-    "geom:area_square_m":75566758285.855316,
+    "geom:area_square_m":75566753204.486725,
     "geom:bbox":"1.943427,29.036367,4.97828,33.029638",
     "geom:latitude":31.162297,
     "geom:longitude":3.117175,
@@ -326,14 +326,16 @@
         "gn:id":2496045,
         "gp:id":2344615,
         "hasc:id":"DZ.GR",
+        "iso:code":"DZ-47",
         "iso:id":"DZ-47",
         "qs_pg:id":423539,
         "unlc:id":"DZ-47",
         "wd:id":"Q17601",
         "wk:page":"Gharda\u00efa Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"db80194ec5ad851f1d161dfa38a31980",
+    "wof:geomhash":"376dff9ec00edf065fb68ae0c4f8db8b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -350,7 +352,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875501,
+    "wof:lastmodified":1695884903,
     "wof:name":"Ghardaia",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/53/85670753.geojson
+++ b/data/856/707/53/85670753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.633126,
-    "geom:area_square_m":27130028706.710953,
+    "geom:area_square_m":27130030764.448509,
     "geom:bbox":"1.336229,32.695989,4.176211,34.69287",
     "geom:latitude":33.559921,
     "geom:longitude":2.699189,
@@ -366,13 +366,15 @@
         "gn:id":2491188,
         "gp:id":2344597,
         "hasc:id":"DZ.LG",
+        "iso:code":"DZ-03",
         "iso:id":"DZ-03",
         "qs_pg:id":399887,
         "unlc:id":"DZ-03",
         "wd:id":"Q231748"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"7dc0a67ec9c1b1046ace0e78c35f15d3",
+    "wof:geomhash":"0932fca53e6fd86c69f60c4860612740",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -389,7 +391,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875499,
+    "wof:lastmodified":1695884902,
     "wof:name":"Laghouat",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/59/85670759.geojson
+++ b/data/856/707/59/85670759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":19.882183,
-    "geom:area_square_m":211462155080.158112,
+    "geom:area_square_m":211462162135.835083,
     "geom:bbox":"2.985999,28.461855,9.519708,33.441887",
     "geom:latitude":30.658124,
     "geom:longitude":6.209051,
@@ -378,13 +378,15 @@
         "gn:id":2485794,
         "gp:id":2344620,
         "hasc:id":"DZ.OG",
+        "iso:code":"DZ-30",
         "iso:id":"DZ-30",
         "qs_pg:id":1134894,
         "unlc:id":"DZ-30",
         "wd:id":"Q235709"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"18cd06c3fd3cc172186dff3a11e89df7",
+    "wof:geomhash":"e022e214d1486af9d23730d533833bdf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -401,7 +403,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875496,
+    "wof:lastmodified":1695884902,
     "wof:name":"Ouargla",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/61/85670761.geojson
+++ b/data/856/707/61/85670761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019652,
-    "geom:area_square_m":194763777.522576,
+    "geom:area_square_m":194763453.390688,
     "geom:bbox":"2.96631,36.649934,3.229808,36.814964",
     "geom:latitude":36.724377,
     "geom:longitude":3.090418,
@@ -316,13 +316,15 @@
         "gn:id":2507475,
         "gp:id":2344579,
         "hasc:id":"DZ.AL",
+        "iso:code":"DZ-16",
         "iso:id":"DZ-16",
         "qs_pg:id":1134875,
         "unlc:id":"DZ-16",
         "wd:id":"Q141026"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"fddafee0ee84b7722139e8940318fb00",
+    "wof:geomhash":"161a654ded23d8c73b8db357e5c23bc9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875496,
+    "wof:lastmodified":1695884902,
     "wof:name":"Alger",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/65/85670765.geojson
+++ b/data/856/707/65/85670765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124319,
-    "geom:area_square_m":1231457760.851146,
+    "geom:area_square_m":1231457921.468784,
     "geom:bbox":"3.17329,36.597327,4.039463,36.917222",
     "geom:latitude":36.765474,
     "geom:longitude":3.6832,
@@ -336,14 +336,16 @@
         "gn:id":2502638,
         "gp:id":2344610,
         "hasc:id":"DZ.BM",
+        "iso:code":"DZ-35",
         "iso:id":"DZ-35",
         "qs_pg:id":1168608,
         "unlc:id":"DZ-35",
         "wd:id":"Q236752",
         "wk:page":"Boumerd\u00e8s Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"0eccf48c6b836a2e6b94c5c4c848a8aa",
+    "wof:geomhash":"6f9e0322e8465d6adb919cc40eae5d3f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -360,7 +362,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875499,
+    "wof:lastmodified":1695884479,
     "wof:name":"Boumerdes",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/67/85670767.geojson
+++ b/data/856/707/67/85670767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284924,
-    "geom:area_square_m":2825499565.834358,
+    "geom:area_square_m":2825500368.352717,
     "geom:bbox":"3.733654,36.46625,4.648068,36.911607",
     "geom:latitude":36.679941,
     "geom:longitude":4.223302,
@@ -378,13 +378,15 @@
         "gn:id":2475741,
         "gp:id":2344588,
         "hasc:id":"DZ.TO",
+        "iso:code":"DZ-15",
         "iso:id":"DZ-15",
         "qs_pg:id":399885,
         "unlc:id":"DZ-15",
         "wd:id":"Q233645"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"c775c461d9166cde2ce1eedb26caa769",
+    "wof:geomhash":"b2f6b7de0728888a54da5532503cb9cd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -401,7 +403,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875496,
+    "wof:lastmodified":1695884902,
     "wof:name":"Tizi Ouzou",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/71/85670771.geojson
+++ b/data/856/707/71/85670771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198583,
-    "geom:area_square_m":1972773683.53402,
+    "geom:area_square_m":1972771953.575024,
     "geom:bbox":"1.647786,36.366669,3.03504,36.815863",
     "geom:latitude":36.543145,
     "geom:longitude":2.312122,
@@ -328,14 +328,16 @@
         "gn:id":2476027,
         "gp:id":2344625,
         "hasc:id":"DZ.TP",
+        "iso:code":"DZ-42",
         "iso:id":"DZ-42",
         "qs_pg:id":423541,
         "unlc:id":"DZ-42",
         "wd:id":"Q235814",
         "wk:page":"Tipaza Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"85ccdd83096ae89173c1263882dcc656",
+    "wof:geomhash":"b2e82bc07c6435d016cd39397c96764c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -352,7 +354,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875501,
+    "wof:lastmodified":1695884903,
     "wof:name":"Tipaza",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/77/85670777.geojson
+++ b/data/856/707/77/85670777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.463384,
-    "geom:area_square_m":4625151439.412546,
+    "geom:area_square_m":4625152602.706913,
     "geom:bbox":"1.553167,35.860499,2.661109,36.443151",
     "geom:latitude":36.176066,
     "geom:longitude":2.080172,
@@ -342,14 +342,16 @@
         "gn:id":2508226,
         "gp:id":2344605,
         "hasc:id":"DZ.AD",
+        "iso:code":"DZ-44",
         "iso:id":"DZ-44",
         "qs_pg:id":988719,
         "unlc:id":"DZ-44",
         "wd:id":"Q168953",
         "wk:page":"A\u00efn Defla Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"44434ecdbc82e35c97e6d42bf15dece9",
+    "wof:geomhash":"d54d6ac7cb744c102145c58e5fffaad8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -366,7 +368,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875500,
+    "wof:lastmodified":1695884479,
     "wof:name":"A\u00efn Defla",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/81/85670781.geojson
+++ b/data/856/707/81/85670781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.431956,
-    "geom:area_square_m":4308345857.094215,
+    "geom:area_square_m":4308346272.209496,
     "geom:bbox":"0.702366,35.841559,1.719203,36.547919",
     "geom:latitude":36.232518,
     "geom:longitude":1.260462,
@@ -365,13 +365,15 @@
         "gn:id":2501296,
         "gp:id":2344611,
         "hasc:id":"DZ.CH",
+        "iso:code":"DZ-02",
         "iso:id":"DZ-02",
         "qs_pg:id":911307,
         "unlc:id":"DZ-02",
         "wd:id":"Q231752"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"b94d1841256303ccf73db50f2dfebcfd",
+    "wof:geomhash":"c91220598896b90f6d31f3822aef725e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -388,7 +390,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875498,
+    "wof:lastmodified":1695884902,
     "wof:name":"Chlef",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/85/85670785.geojson
+++ b/data/856/707/85/85670785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.572815,
-    "geom:area_square_m":5774250136.084955,
+    "geom:area_square_m":5774249376.609795,
     "geom:bbox":"-0.545362,35.02148,0.880494,35.783759",
     "geom:latitude":35.389594,
     "geom:longitude":0.143033,
@@ -402,13 +402,15 @@
         "gn:id":2490095,
         "gp:id":2344598,
         "hasc:id":"DZ.MC",
+        "iso:code":"DZ-29",
         "iso:id":"DZ-29",
         "qs_pg:id":264448,
         "unlc:id":"DZ-29",
         "wd:id":"Q236776"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"f515f77617b4e1ba5ecb18ca5ca3978c",
+    "wof:geomhash":"a72b3cadfef20bd89368c4e0e3f2338d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -425,7 +427,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875501,
+    "wof:lastmodified":1695884903,
     "wof:name":"Mascara",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/87/85670787.geojson
+++ b/data/856/707/87/85670787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.222798,
-    "geom:area_square_m":2228990258.380057,
+    "geom:area_square_m":2228990555.520115,
     "geom:bbox":"-0.11438,35.68206,0.741278,36.337758",
     "geom:latitude":35.99256,
     "geom:longitude":0.331803,
@@ -318,13 +318,15 @@
         "gn:id":2487130,
         "gp:id":2344583,
         "hasc:id":"DZ.MG",
+        "iso:code":"DZ-27",
         "iso:id":"DZ-27",
         "qs_pg:id":1134878,
         "unlc:id":"DZ-27",
         "wd:id":"Q849524"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"bd34fa42dbb39f59ebb9c2edb91e85f8",
+    "wof:geomhash":"f29e8465bd5537706ddd122737447cde",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -341,7 +343,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875497,
+    "wof:lastmodified":1695884902,
     "wof:name":"Mostaganem",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/91/85670791.geojson
+++ b/data/856/707/91/85670791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.489007,
-    "geom:area_square_m":4904609933.623497,
+    "geom:area_square_m":4904609795.589678,
     "geom:bbox":"0.229371,35.43608,1.411625,36.201357",
     "geom:latitude":35.793638,
     "geom:longitude":0.800795,
@@ -361,13 +361,15 @@
         "gn:id":2483666,
         "gp:id":2344621,
         "hasc:id":"DZ.RE",
+        "iso:code":"DZ-48",
         "iso:id":"DZ-48",
         "qs_pg:id":114057,
         "unlc:id":"DZ-48",
         "wd:id":"Q236758"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"d874e4442e7ad082093f01e1cb65cf01",
+    "wof:geomhash":"64f35fb595f33b14753be295df8ffbb9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -384,7 +386,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875499,
+    "wof:lastmodified":1695884903,
     "wof:name":"Relizane",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/707/97/85670797.geojson
+++ b/data/856/707/97/85670797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.909873,
-    "geom:area_square_m":9261101767.840248,
+    "geom:area_square_m":9261101236.322775,
     "geom:bbox":"-0.49968,33.915036,0.856878,35.160593",
     "geom:latitude":34.593407,
     "geom:longitude":0.171261,
@@ -339,14 +339,16 @@
         "gn:id":2482557,
         "gp:id":2344585,
         "hasc:id":"DZ.SD",
+        "iso:code":"DZ-20",
         "iso:id":"DZ-20",
         "qs_pg:id":1046062,
         "unlc:id":"DZ-20",
         "wd:id":"Q233640",
         "wk:page":"Sa\u00efda Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"252838958a2832ababea186944658f8d",
+    "wof:geomhash":"95c21db7fdf76823c3fbcb3feb4ec0ff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -363,7 +365,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875500,
+    "wof:lastmodified":1695884903,
     "wof:name":"Saida",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/01/85670801.geojson
+++ b/data/856/708/01/85670801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.001296,
-    "geom:area_square_m":20281270046.175861,
+    "geom:area_square_m":20281268854.900734,
     "geom:bbox":"0.492249,34.068929,2.620285,35.689812",
     "geom:latitude":34.957859,
     "geom:longitude":1.51563,
@@ -366,13 +366,15 @@
         "gn:id":2476893,
         "gp:id":2344587,
         "hasc:id":"DZ.TR",
+        "iso:code":"DZ-14",
         "iso:id":"DZ-14",
         "qs_pg:id":963007,
         "unlc:id":"DZ-14",
         "wd:id":"Q233258"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"53bb67e65fbc650a5d4c2cb290c6d81a",
+    "wof:geomhash":"98479ca60b62acc28c07760bc842da9a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -389,7 +391,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875494,
+    "wof:lastmodified":1695884902,
     "wof:name":"Tiaret",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/05/85670805.geojson
+++ b/data/856/708/05/85670805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301246,
-    "geom:area_square_m":3023249707.209126,
+    "geom:area_square_m":3023250817.086847,
     "geom:bbox":"1.245588,35.544032,2.311777,36.005658",
     "geom:latitude":35.745807,
     "geom:longitude":1.800488,
@@ -348,13 +348,15 @@
         "gn:id":2475858,
         "gp:id":2344626,
         "hasc:id":"DZ.TS",
+        "iso:code":"DZ-38",
         "iso:id":"DZ-38",
         "qs_pg:id":1134901,
         "unlc:id":"DZ-38",
         "wd:id":"Q235805"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"c8b6556ac960337f20dad4441e2773a6",
+    "wof:geomhash":"36012c76839bf33b06689a75c53142c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -371,7 +373,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875492,
+    "wof:lastmodified":1695884902,
     "wof:name":"Tissemsilt",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/09/85670809.geojson
+++ b/data/856/708/09/85670809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404891,
-    "geom:area_square_m":4045987894.618408,
+    "geom:area_square_m":4045988935.061145,
     "geom:bbox":"4.08433,35.777326,5.254181,36.42478",
     "geom:latitude":36.085273,
     "geom:longitude":4.730866,
@@ -322,14 +322,16 @@
         "gn:id":2503699,
         "gp:id":2344609,
         "hasc:id":"DZ.BB",
+        "iso:code":"DZ-34",
         "iso:id":"DZ-34",
         "qs_pg:id":318266,
         "unlc:id":"DZ-34",
         "wd:id":"Q266411",
         "wk:page":"Bordj Bou Arr\u00e9ridj Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"619497152bc2280a0c4f5adc8dd104c9",
+    "wof:geomhash":"eb0f3a52d965e71fa2fce001fa5cdfe6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -346,7 +348,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875493,
+    "wof:lastmodified":1695884479,
     "wof:name":"Bordj Bou Arr\u00e9ridj",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/15/85670815.geojson
+++ b/data/856/708/15/85670815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.356546,
-    "geom:area_square_m":3540770815.316984,
+    "geom:area_square_m":3540769610.487211,
     "geom:bbox":"4.356355,36.222906,5.475459,36.898017",
     "geom:latitude":36.570385,
     "geom:longitude":4.846781,
@@ -340,14 +340,16 @@
         "gn:id":2505325,
         "gp:id":2344590,
         "hasc:id":"DZ.BJ",
+        "iso:code":"DZ-06",
         "iso:id":"DZ-06",
         "qs_pg:id":894840,
         "unlc:id":"DZ-06",
         "wd:id":"Q233665",
         "wk:page":"B\u00e9ja\u00efa Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"9b90e78780c60b04125ed033ed9a95eb",
+    "wof:geomhash":"3dac4ef5846e6d9f674b38809847a0e0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -364,7 +366,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875495,
+    "wof:lastmodified":1695884479,
     "wof:name":"B\u00e9jaia",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/19/85670819.geojson
+++ b/data/856/708/19/85670819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195295,
-    "geom:area_square_m":1940529883.486264,
+    "geom:area_square_m":1940528837.492235,
     "geom:bbox":"2.476263,36.353285,3.51036,36.71347",
     "geom:latitude":36.526746,
     "geom:longitude":2.999735,
@@ -408,13 +408,15 @@
         "gn:id":2503765,
         "gp:id":2344592,
         "hasc:id":"DZ.BL",
+        "iso:code":"DZ-09",
         "iso:id":"DZ-09",
         "qs_pg:id":1134890,
         "unlc:id":"DZ-09",
         "wd:id":"Q233637"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"5fa8a43c462ffb05d2d5f0fd12d016c4",
+    "wof:geomhash":"1c7ef69c50db7132a704d5761bcee1ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -431,7 +433,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875493,
+    "wof:lastmodified":1695884902,
     "wof:name":"Blida",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/23/85670823.geojson
+++ b/data/856/708/23/85670823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.454634,
-    "geom:area_square_m":4531948484.869579,
+    "geom:area_square_m":4531948431.823167,
     "geom:bbox":"3.283035,35.861119,4.404465,36.695797",
     "geom:latitude":36.27712,
     "geom:longitude":3.849002,
@@ -348,13 +348,15 @@
         "gn:id":2502951,
         "gp:id":2344593,
         "hasc:id":"DZ.BU",
+        "iso:code":"DZ-10",
         "iso:id":"DZ-10",
         "qs_pg:id":1134883,
         "unlc:id":"DZ-10",
         "wd:id":"Q233655"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"654a4086a7183717a461e1bdcfbb4325",
+    "wof:geomhash":"443d95256dd1d5924af6d450020b7d9a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -371,7 +373,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875495,
+    "wof:lastmodified":1695884902,
     "wof:name":"Bouira",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/27/85670827.geojson
+++ b/data/856/708/27/85670827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.042794,
-    "geom:area_square_m":20817054471.325794,
+    "geom:area_square_m":20817049656.803616,
     "geom:bbox":"4.184427,33.57268,6.749542,35.288441",
     "geom:latitude":34.5022,
     "geom:longitude":5.344496,
@@ -329,13 +329,15 @@
         "gn:id":2503822,
         "gp:id":2344591,
         "hasc:id":"DZ.BS",
+        "iso:code":"DZ-07",
         "iso:id":"DZ-07",
         "qs_pg:id":1134887,
         "unlc:id":"DZ-07",
         "wd:id":"Q458402"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"5de2bf7b3617501a443f0da4967252c2",
+    "wof:geomhash":"f9c28cd70e6ef3028a75ea0dfc48aee5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -352,7 +354,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875492,
+    "wof:lastmodified":1695884902,
     "wof:name":"Biskra",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/33/85670833.geojson
+++ b/data/856/708/33/85670833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.443764,
-    "geom:area_square_m":35161419911.10183,
+    "geom:area_square_m":35161419922.394714,
     "geom:bbox":"2.285732,32.840761,5.121786,35.80474",
     "geom:latitude":34.332577,
     "geom:longitude":3.550843,
@@ -362,13 +362,15 @@
         "gn:id":2500013,
         "gp:id":2344594,
         "hasc:id":"DZ.DJ",
+        "iso:code":"DZ-17",
         "iso:id":"DZ-17",
         "qs_pg:id":1134891,
         "unlc:id":"DZ-17",
         "wd:id":"Q233233"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"c6e558d6fbb95f65ed93849c77ae968e",
+    "wof:geomhash":"acd1149206123e45c15ae5fa93f42317",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -385,7 +387,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875491,
+    "wof:lastmodified":1695884902,
     "wof:name":"Djelfa",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/37/85670837.geojson
+++ b/data/856/708/37/85670837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.904332,
-    "geom:area_square_m":9049570038.06196,
+    "geom:area_square_m":9049569320.748617,
     "geom:bbox":"2.158194,35.439077,3.633866,36.490176",
     "geom:latitude":35.973555,
     "geom:longitude":2.93701,
@@ -339,14 +339,16 @@
         "gn:id":2488831,
         "gp:id":2344582,
         "hasc:id":"DZ.MD",
+        "iso:code":"DZ-26",
         "iso:id":"DZ-26",
         "qs_pg:id":1284958,
         "unlc:id":"DZ-26",
         "wd:id":"Q235810",
         "wk:page":"M\u00e9d\u00e9a Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"1ad4dbfefe9a4f3f52142111a45f2493",
+    "wof:geomhash":"76d789d0bcedf869fcc92f309d292eb9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -363,7 +365,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875493,
+    "wof:lastmodified":1695884479,
     "wof:name":"Medea",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/41/85670841.geojson
+++ b/data/856/708/41/85670841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.749396,
-    "geom:area_square_m":17653832990.630157,
+    "geom:area_square_m":17653832985.945061,
     "geom:bbox":"3.379515,34.2322,5.379703,36.029093",
     "geom:latitude":35.300692,
     "geom:longitude":4.2764,
@@ -364,12 +364,14 @@
         "gn:id":2486682,
         "gp:id":2344599,
         "hasc:id":"DZ.MS",
+        "iso:code":"DZ-28",
         "iso:id":"DZ-28",
         "qs_pg:id":224178,
         "wd:id":"Q240870"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"602127d73bbf45a81968c629ac48b3d5",
+    "wof:geomhash":"9a56c6cf6cfcd842050ba54bf8d20ea1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -386,7 +388,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875494,
+    "wof:lastmodified":1695884902,
     "wof:name":"M'sila",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/45/85670845.geojson
+++ b/data/856/708/45/85670845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.619979,
-    "geom:area_square_m":6191428104.632976,
+    "geom:area_square_m":6191426993.444172,
     "geom:bbox":"4.785217,35.632399,5.983335,36.590635",
     "geom:latitude":36.134258,
     "geom:longitude":5.465657,
@@ -327,14 +327,16 @@
         "gn:id":2481696,
         "gp:id":2344586,
         "hasc:id":"DZ.SF",
+        "iso:code":"DZ-19",
         "iso:id":"DZ-19",
         "qs_pg:id":1046063,
         "unlc:id":"DZ-19",
         "wd:id":"Q237164",
         "wk:page":"S\u00e9tif Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"ab965c369f0938d21d065b50849a4f74",
+    "wof:geomhash":"b88bc9ff9911fa803848489fb67ea332",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -351,7 +353,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875492,
+    "wof:lastmodified":1695884479,
     "wof:name":"S\u00e9tif",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/51/85670851.geojson
+++ b/data/856/708/51/85670851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.19653,
-    "geom:area_square_m":12055802158.28751,
+    "geom:area_square_m":12055804238.533699,
     "geom:bbox":"4.777001,34.764493,6.787266,35.915793",
     "geom:latitude":35.427852,
     "geom:longitude":5.883069,
@@ -346,13 +346,15 @@
         "gn:id":2505569,
         "gp:id":2344580,
         "hasc:id":"DZ.BT",
+        "iso:code":"DZ-05",
         "iso:id":"DZ-05",
         "qs_pg:id":1134876,
         "unlc:id":"DZ-05",
         "wd:id":"Q215452"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"9189c90dc7573a9dbaf8b621840fe528",
+    "wof:geomhash":"b1295c17c9573162b314333d005325c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -369,7 +371,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875491,
+    "wof:lastmodified":1695884902,
     "wof:name":"Batna",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/55/85670855.geojson
+++ b/data/856/708/55/85670855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.212812,
-    "geom:area_square_m":2119486963.512141,
+    "geom:area_square_m":2119486683.564765,
     "geom:bbox":"6.317734,36.106892,7.048283,36.607895",
     "geom:latitude":36.347293,
     "geom:longitude":6.70924,
@@ -375,13 +375,15 @@
         "gn:id":2501147,
         "gp:id":2344581,
         "hasc:id":"DZ.CO",
+        "iso:code":"DZ-25",
         "iso:id":"DZ-25",
         "qs_pg:id":1134877,
         "unlc:id":"DZ-25",
         "wd:id":"Q232043"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"e81a0146223d0a7b5e474de000d50357",
+    "wof:geomhash":"5bd06832bcaf8c64bceff5952a5dd0a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -398,7 +400,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875494,
+    "wof:lastmodified":1695884902,
     "wof:name":"Constantine",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/57/85670857.geojson
+++ b/data/856/708/57/85670857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.380125,
-    "geom:area_square_m":3783132739.783228,
+    "geom:area_square_m":3783131789.525305,
     "geom:bbox":"6.937954,36.042503,7.987864,36.726131",
     "geom:latitude":36.402211,
     "geom:longitude":7.399147,
@@ -366,13 +366,15 @@
         "gn:id":2495659,
         "gp:id":2344595,
         "hasc:id":"DZ.GL",
+        "iso:code":"DZ-24",
         "iso:id":"DZ-24",
         "qs_pg:id":1134889,
         "unlc:id":"DZ-24",
         "wd:id":"Q235727"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"17bb1d28414c998641f05c5b78f30f9b",
+    "wof:geomhash":"d56a3e158f4971a391b7c2dd8530f82a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -389,7 +391,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875491,
+    "wof:lastmodified":1695884902,
     "wof:name":"Guelma",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/61/85670861.geojson
+++ b/data/856/708/61/85670861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.972928,
-    "geom:area_square_m":9857676029.930212,
+    "geom:area_square_m":9857673922.519957,
     "geom:bbox":"6.5109,34.160577,7.544842,35.68392",
     "geom:latitude":34.974376,
     "geom:longitude":6.999357,
@@ -371,13 +371,15 @@
         "gn:id":2491887,
         "gp:id":2344617,
         "hasc:id":"DZ.KH",
+        "iso:code":"DZ-40",
         "iso:id":"DZ-40",
         "qs_pg:id":1134893,
         "unlc:id":"DZ-40",
         "wd:id":"Q213950"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"8fa0e81844b87b35ba863b27c6c0a175",
+    "wof:geomhash":"f624faa925f812ab93ee8aa7174920cc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -394,7 +396,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875490,
+    "wof:lastmodified":1695884902,
     "wof:name":"Khenchela",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/67/85670867.geojson
+++ b/data/856/708/67/85670867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.356228,
-    "geom:area_square_m":3550203926.635746,
+    "geom:area_square_m":3550205918.314277,
     "geom:bbox":"5.737201,35.892797,6.525008,36.624251",
     "geom:latitude":36.294398,
     "geom:longitude":6.158336,
@@ -342,13 +342,15 @@
         "gn:id":2487449,
         "gp:id":2344618,
         "hasc:id":"DZ.ML",
+        "iso:code":"DZ-43",
         "iso:id":"DZ-43",
         "qs_pg:id":1134896,
         "unlc:id":"DZ-43",
         "wd:id":"Q235723"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"01f5980af17fb99706438019c5bf7707",
+    "wof:geomhash":"e504c301200a4a0891a47f5bd23b2872",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -365,7 +367,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875491,
+    "wof:lastmodified":1695884902,
     "wof:name":"Mila",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/71/85670871.geojson
+++ b/data/856/708/71/85670871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.632048,
-    "geom:area_square_m":6335020804.509668,
+    "geom:area_square_m":6335019171.812379,
     "geom:bbox":"6.148442,35.447811,7.865856,36.192442",
     "geom:latitude":35.847475,
     "geom:longitude":7.081928,
@@ -334,14 +334,16 @@
         "gn:id":2484618,
         "gp:id":2344600,
         "hasc:id":"DZ.OB",
+        "iso:code":"DZ-04",
         "iso:id":"DZ-04",
         "qs_pg:id":257791,
         "unlc:id":"DZ-04",
         "wd:id":"Q235705",
         "wk:page":"Oum El Bouaghi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"8ccb4ccca1cffba9ee1192b79791373a",
+    "wof:geomhash":"892b3c258d6c7fa56bba2a71800eeb68",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -358,7 +360,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875495,
+    "wof:lastmodified":1695884902,
     "wof:name":"Oum el Bouaghi",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/75/85670875.geojson
+++ b/data/856/708/75/85670875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.40384,
-    "geom:area_square_m":4031875851.389768,
+    "geom:area_square_m":4031875002.997869,
     "geom:bbox":"7.324959,35.830992,8.359675,36.491995",
     "geom:latitude":36.155775,
     "geom:longitude":7.886955,
@@ -369,13 +369,15 @@
         "gn:id":2479213,
         "gp:id":2344622,
         "hasc:id":"DZ.SA",
+        "iso:code":"DZ-41",
         "iso:id":"DZ-41",
         "qs_pg:id":1134899,
         "unlc:id":"DZ-41",
         "wd:id":"Q236772"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"687c00b69b29de13b8e2ffb2cd3eb173",
+    "wof:geomhash":"f54c34c29216ba4281fe685f917d7e60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -392,7 +394,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875493,
+    "wof:lastmodified":1695884902,
     "wof:name":"Souk Ahras",
     "wof:parent_id":85632451,
     "wof:placetype":"region",

--- a/data/856/708/79/85670879.geojson
+++ b/data/856/708/79/85670879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.329726,
-    "geom:area_square_m":13467309426.313122,
+    "geom:area_square_m":13467310423.713881,
     "geom:bbox":"7.135772,34.108306,8.431299,36.004211",
     "geom:latitude":35.005761,
     "geom:longitude":7.810236,
@@ -318,14 +318,16 @@
         "gn:id":2477457,
         "gp:id":2344603,
         "hasc:id":"DZ.TB",
+        "iso:code":"DZ-12",
         "iso:id":"DZ-12",
         "qs_pg:id":988718,
         "unlc:id":"DZ-12",
         "wd:id":"Q267224",
         "wk:page":"T\u00e9bessa Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DZ",
-    "wof:geomhash":"72315e24dbef2f966c505ce17dee6afc",
+    "wof:geomhash":"a29e29dca372180c9ad1970bfae4a153",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -342,7 +344,7 @@
         "ara",
         "fra"
     ],
-    "wof:lastmodified":1690875494,
+    "wof:lastmodified":1695884479,
     "wof:name":"T\u00e9bessa",
     "wof:parent_id":85632451,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.